### PR TITLE
Release 1.4.0

### DIFF
--- a/.claude/skills/install-llmify/SKILL.md
+++ b/.claude/skills/install-llmify/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: install-llmify
+description: Install and configure the LLMify Craft CMS plugin step by step
+---
+
+# Install and Configure LLMify for Craft CMS
+
+This guide tells an AI agent how to install and set up the LLMify plugin in a Craft CMS 5 project.
+
+## Prerequisites
+
+- Craft CMS 5 or later
+- PHP 8.2 or later
+
+## Step 1: Install the Plugin
+
+Run the following commands in the Craft project root:
+
+```bash
+composer require samuelreichor/craft-llmify
+php craft plugin/install llmify
+```
+
+If the project uses DDEV:
+
+```bash
+ddev composer require samuelreichor/craft-llmify
+ddev craft plugin/install llmify
+```
+
+## Step 2: Enable Sections
+
+1. In the Craft control panel, go to **LLMify → Content**.
+2. Enable each section that should produce markdown output using the **Enable for Section** toggle.
+3. Set an **LLM Title** and **LLM Description** for each enabled section — these populate the `llms.txt` file.
+
+## Step 3: Add Template Tags
+
+Wrap the content you want converted to markdown with the `{% llmify %}` tag in your Twig templates:
+
+```twig
+{% llmify %}
+  <h1>{{ entry.title }}</h1>
+  <div>{{ entry.bodyContent }}</div>
+{% endllmify %}
+```
+
+Multiple `{% llmify %}` blocks per template are supported — their content is merged into a single markdown file.
+
+To exclude specific parts within an llmify block:
+
+```twig
+{% llmify %}
+  <h1>{{ entry.title }}</h1>
+  {% excludellmify %}
+    <nav>...</nav>
+  {% endexcludellmify %}
+  <div>{{ entry.bodyContent }}</div>
+{% endllmify %}
+```
+
+You can also exclude content by adding the `exclude-llmify` CSS class to any HTML element. This class name is configurable via the config file.
+
+## Step 4: Generate Markdown
+
+Generate markdown for all enabled entries using one of these methods:
+
+- **Control Panel**: Go to **Utilities → LLMify** and trigger generation.
+- **Entry Sidebar**: Generate markdown for a single entry from its edit page.
+- **Console Command**:
+  ```bash
+  php craft llmify/markdown/generate
+  ```
+
+To clear all generated markdown and start fresh:
+
+```bash
+php craft llmify/markdown/clear
+```
+
+## Step 5: Check the Dashboard
+
+Go to **LLMify → Dashboard** to see an overview of your setup:
+
+- **Site setup score** — shows how complete your site-level configuration is (LLM title, description, note, front matter fields).
+- **Section statistics** — content-level stats per section showing how many entries have markdown generated.
+
+## Step 6: Verify the Output
+
+After generating markdown, verify these URLs are accessible:
+
+- `/llms.txt` — Summary file listing all enabled entries
+- `/llms-full.txt` — Full content of all entries
+- `/.well-known/llms.txt` — RFC 8615 compliant discovery endpoint
+- `/raw/{entry-uri}.md` — Individual markdown page (if `markdownUrlPrefix` is set)
+
+Test auto-serve markdown with:
+
+```bash
+curl -H "Accept: text/markdown" https://your-site.com/your-entry-url
+```
+
+## Full Documentation
+
+For detailed configuration options and advanced usage, see the [LLMify documentation](https://samuelreichor.at/libraries/craft-llmify).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Release Notes for LLMify
 
+## 1.4.0 - 2026-04-11
+
+### Added
+- Add dashboard with site setup scores and section-level content statistics.
+- Add AI crawler detection to auto-serve markdown to known bots (GPTBot, ClaudeBot, ChatGPT-User, and more) based on user agent.
+- Add `<link rel="alternate" type="text/markdown">` discovery tag injection with configurable toggle.
+- Add `/.well-known/llms.txt` route for RFC 8615 compliant discovery.
+- Add per-entry exclude toggle via the LlmifySettingsField to individually exclude entries from markdown generation and all LLM outputs.
+- Add SEOmatic field support for automatic front matter population.
+- Add `Vary: Accept` header to all markdown endpoints and `Vary: Accept, User-Agent` to auto-serve responses.
+- Add `X-Robots-Tag: noindex, nofollow` header to auto-serve responses.
+- Add custom bot user agent configuration for extending the built-in bot list.
+- Add markdown preview targets for entries and products.
+- Add direct links to content and site settings from the entry sidebar and settings field.
+
+### Improved
+- Reorganize plugin settings into a tabbed UI (General, Advanced) integrated into the plugin subnav.
+- Enable content negotiation (`autoServeMarkdown`) and AI crawler detection (`enableBotDetection`) by default for fresh installs.
+- Make `markdownUrlPrefix` optional, leave it empty to use `${url}.md` URLs directly.
+- Refactor field discovery into dedicated `FieldDiscoveryService`.
+- Improve sidebar panel UX: show informative messages when LLMify is disabled at the site, section, or entry level instead of hiding the panel. Respect generate and clear permissions for sidebar buttons.
+- Enhance markdown generation for images inside links.
+
+### Fixed
+- Fix breadcrumbs in all plugin pages.
+- Fix bug in field discovery service with field layout overwrites.
+- Fix UI issue with front matter inheritance in the settings field.
+- Fix issue with cached SEOmatic field values in llms.txt.
+
 ## 1.3.1 - 2026-03-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-LLMify is a Craft CMS 5 plugin that transforms site content into AI-ready formats. It generates clean markdown versions of Twig templates and produces `llms.txt` and `llms-full.txt` files for LLM consumption.
+LLMify is a Craft CMS 5 plugin (PHP 8.2+) that transforms site content into AI-ready formats. It generates clean markdown versions of Twig templates, produces `llms.txt` and `llms-full.txt` files for LLM consumption, detects AI bots, and can auto-serve markdown content. Supports both Craft Entries and Commerce Products.
+
+Namespace: `samuelreichor\llmify`
 
 ## Development Commands
 
 ```bash
-# Code style (ECS with Craft CMS rules)
+# Code style (ECS with Craft CMS rules via ecs.php)
 composer check-cs      # Check code style
 composer fix-cs        # Fix code style issues
 
@@ -21,32 +23,54 @@ php craft llmify/markdown/generate  # Generate markdown for all enabled entries
 php craft llmify/markdown/clear     # Clear all generated markdown
 ```
 
+CI runs PHPStan + ECS on every pull request to `main` (`.github/workflows/ci.yml`). No test suite in this repo — testing is handled externally.
+
 ## Architecture
 
 ### Plugin Entry Point
-`src/Llmify.php` - Registers services, Twig extensions, event listeners, and URL rules. Services are defined in `config()` and accessed as plugin components (e.g., `Llmify::getInstance()->markdown`).
+`src/Llmify.php` (~700 lines) - Registers services, Twig extensions, event listeners, URL rules, permissions, and sidebar panels. Services are defined in `config()` and accessed as plugin components (e.g., `Llmify::getInstance()->markdown`).
 
 ### Services (`src/services/`)
+Core services:
 - **MarkdownService** - Converts HTML to markdown using `league/html-to-markdown`, stores results in `llmify_pages` table
-- **RefreshService** - Handles markdown regeneration triggered by element changes, uses queue jobs for processing
+- **RefreshService** - Handles markdown regeneration triggered by element changes, uses queue jobs (`src/jobs/RefreshMarkdownJob.php`)
 - **SettingsService** - Manages per-section and per-site configuration stored in `llmify_globals` table
 - **RequestService** - Makes async HTTP requests using `amphp/http-client` to fetch rendered pages for markdown conversion
 
-### Twig Extension (`src/twig/`)
-Custom Twig tags `{% llmify %}...{% endllmify %}` and `{% excludellmify %}...{% endexcludellmify %}` control what HTML content is included/excluded in markdown output.
+Supporting services:
+- **BotDetectionService** - Detects AI crawlers (GPTBot, ClaudeBot, ChatGPT-User, etc.) via user-agent
+- **DashboardService** - Calculates site setup scores and section statistics for the CP dashboard
+- **FieldDiscoveryService** - Discovers relevant fields (including SEOmatic) for markdown generation
+- **FrontMatterService** - Generates YAML front matter from SEOmatic fields and metadata
+- **HelperService** - Utility functions (markdown URL generation, feature availability checks)
+- **LlmsService** - Generates `llms.txt` and `llms-full.txt` content
+- **MetadataService** - Manages element metadata storage and retrieval
+- **PermissionService** - Permission management (Pro Edition only)
+
+### Key Components
+- **Twig Extension** (`src/twig/`) - Custom tags `{% llmify %}...{% endllmify %}` and `{% excludellmify %}...{% endexcludellmify %}` control what HTML is included/excluded in markdown output
+- **LlmifySettingsField** (`src/fields/`) - Custom Craft field for per-entry markdown control
+- **LlmifyChangedBehavior** (`src/behaviors/`) - Attached to elements to track changes and trigger refresh
+- **SiteUrlBatcher** (`src/batchers/`) - Collects URLs in batches for async processing
+- **Constants** (`src/Constants.php`) - Database table names, permission constants, and `X-Llmify-Refresh-Request` header
 
 ### Models & Records
 - **Models** (`src/models/`) - Data objects: `Page`, `ContentSettings`, `GlobalSettings`, `PluginSettings`
-- **Records** (`src/records/`) - ActiveRecord classes for database tables
+- **Records** (`src/records/`) - ActiveRecord classes for `llmify_pages`, `llmify_metadata`, `llmify_globals`
 
 ### Event-Driven Architecture
-The plugin listens to Craft element events (save, delete, restore, move) to automatically queue markdown regeneration. Element changes are tracked via `LlmifyChangedBehavior`.
+The plugin listens to Craft element events (save, delete, restore, move) to automatically queue markdown regeneration. Element changes are tracked via `LlmifyChangedBehavior`. Auto-serve mode intercepts template rendering to return markdown instead of HTML when an `Accept: text/markdown` header is present or an AI bot is detected.
 
 ### URL Routes
-Site routes registered for:
-- `/llms.txt` - Summary text file
+Site routes:
+- `/llms.txt` and `/.well-known/llms.txt` - Summary text file
 - `/llms-full.txt` - Full content file
 - `/{prefix}/<slug>.md` - Individual markdown pages (prefix configurable, default: `raw`)
+
+CP routes under `llmify/`: dashboard, content (per-section settings), globals (per-site settings), settings (plugin config).
+
+### Commerce Support
+Soft dependency on Craft Commerce — supports Product elements alongside Entries. Commerce-related PHPStan errors are ignored in `phpstan.neon`.
 
 ## Key Dependencies
 - `amphp/http-client` - Async HTTP requests for batch processing
@@ -54,13 +78,19 @@ Site routes registered for:
 - `paquettg/php-html-parser` - DOM manipulation for excluding content by CSS class
 
 ## Database Tables
-- `llmify_pages` - Stores generated markdown content per entry/site
+Defined in `src/Constants.php` and created by `src/migrations/Install.php`:
+- `llmify_pages` - Stores generated markdown content per element/site (supports entries and products via `elementType` column)
 - `llmify_globals` - Site-level settings
-- `llmify_metadata` - Content metadata
+- `llmify_metadata` - Content metadata per group/element type
 
 ## Plugin Settings
-Configurable via `config/llmify.php`:
+Configurable via `config/llmify.php` (see `src/models/PluginSettings.php` for all options):
 - `isEnabled` - Master toggle
-- `markdownUrlPrefix` - URL prefix for markdown files
+- `markdownUrlPrefix` - URL prefix for markdown files (default: `raw`)
 - `excludeClasses` - CSS classes to exclude from output
 - `markdownConfig` - Options passed to HTML-to-markdown converter
+- `enableAutoServe` - Serve markdown on `Accept: text/markdown` header
+- `enableBotDetection` - Auto-detect AI crawlers and serve markdown
+- `enableDiscoveryTag` - Inject `<link rel="alternate" type="text/markdown">` tags
+- `enableSeomatic` - Pull front matter from SEOmatic fields
+- `concurrentRequests` / `requestTimeout` - Async request tuning

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <br>
 	<h1 align="center">Supercharge Your Craft CMS Content for AI</h1>
   <p align="center">
-    LLMify makes your Craft CMS content instantly AI-ready. It transforms your templates into clean, structured outputs, giving you full control over what’s included. 
+    LLMify makes your Craft CMS content instantly AI-ready. It transforms your templates into clean, structured outputs, giving you full control over what's included. 
   <br/>
 </div>
 
@@ -24,17 +24,42 @@
   </a>
 </p>
 
+## Why LLMify?
+
+AI models like ChatGPT struggle to read websites built for people. They see a wall of code, menus, ads, and sidebars. This "noise" makes it hard for them to find the real story - your valuable story.
+LLMify solves this by converting your Twig templates into clean, structured Markdown.
+
+LLMify is built for production-scale AI content delivery.
+Instead of converting HTML to Markdown on every request, LLMify does the work upfront. Your Markdown is stored and ready before any bot shows up.
+Combined with Craft Commerce compatibility, granular control over your Markdowns and user permissions, LLMify gives you everything you need to make your entire site AI-ready.
+
 ## Features
 
-- **Automatic Markdown Output**: Creates clean Markdown versions of your Twig templates.
-- **Auto-Serve Markdown**: Serve markdown instead of HTML based on the Accept: text/markdown header.
-- **LLM-Ready Text Files**: Generates `llms.txt` (summary) and `llms-full.txt` (full content).
-- **Twig Tags for Control**: Use `{% llmify %}` to include or `{% excludellmify %}` to exclude HTML from the output.
-- **Exclude Tags with Classes**: Define classes that should be excluded from the HTML output.
-- **Flexible Configuration**: Site-wide, section, and entry-level settings.
-- **Craft Commerce Support**: Out of the box support for commerce products. 
-- **YAML Front Matter**: Add configurable metadata to your Markdown.
-- **Easy Refresh Options**: Automatic background jobs, manual updates in the CP, or console commands for deployments.
+### Content Generation
+- **Pre-Generated Markdown**: Async batch processing with [amphp](https://amphp.org/) stores Markdown in a dedicated database table for instant delivery at any scale.
+- **On-Demand Fallback**: Automatically generates Markdown on first request if not yet pre-generated.
+- **Template-Level Control**: Use `{% llmify %}` and `{% excludellmify %}` Twig tags for precise control over what content is included in your Markdown output.
+- **CSS Class Exclusion**: Define classes to exclude entire sections from the HTML-to-Markdown conversion.
+- **YAML Front Matter**: Configurable metadata with hierarchical inheritance (Site > Section > Entry).
+- **Console Commands**: `llmify/markdown/generate` and `llmify/markdown/clear` for CI/CD and deployment workflows.
+
+### AI Content Delivery
+- **Auto-Serve Markdown**: Content negotiation via `Accept: text/markdown` header.
+- **AI Crawler Detection**: Automatically serve Markdown to known AI bots (GPTBot, ClaudeBot, ChatGPT-User, and more).
+- **LLM-Ready Text Files**: Generates `llms.txt`, `llms-full.txt`, and `/.well-known/llms.txt`.
+- **Discovery Tag**: Injects `<link rel="alternate" type="text/markdown">` into your HTML head.
+- **Industry Standard Response Headers**: Sets `Vary: Accept` (+ `User-Agent` for auto-serve), `X-Robots-Tag: noindex, nofollow`, and `Link: rel="canonical"` on all Markdown responses.
+
+### Content Management
+- **Hierarchical Settings**: Site-wide, section, and entry-level configuration with inheritance.
+- **Per-Entry Control**: Include or exclude individual entries via the LLMify Settings Field.
+- **Permission System**: Granular user permissions for everything.
+- **Preview Targets**: Preview Markdown output directly from the entry editor.
+- **Dashboard**: Site setup scores and section-level content statistics at a glance.
+
+### Integrations
+- **SEOmatic Integration**: Automatically populate front matter from SEOmatic fields.
+- **Craft Commerce Support**: Full support for Commerce Products alongside Entries.
 
 ## Requirements
 
@@ -42,8 +67,8 @@ This plugin requires Craft CMS 5.0.0 or later, and PHP 8.2 or later.
 
 ## Documentation
 
-Visit the Craft [LLMify documentation](https://samuelreichor.at/libraries/craft-llmify) for all documentation, guides and developer resources.
+Visit the [LLMify documentation](https://samuelreichor.at/libraries/craft-llmify) for all documentation, guides, and developer resources.
 
 ## Support
 
-If you encounter bugs or have feature requests, [please submit an issue](/../../issues/new). Your feedback helps improve the library!
+If you encounter bugs or have feature requests, [please submit an issue](/../../issues/new). Your feedback helps improve the plugin!

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Optimize your site for LLMs",
   "type": "craft-plugin",
   "license": "proprietary",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "support": {
     "email": "samuelreichor@gmail.com",
     "issues": "https://github.com/samuelreichor/craft-llmify/issues?state=open",

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -15,6 +15,7 @@ class Constants
     public const PERMISSION_VIEW_SIDEBAR_PANEL = 'llmify:view-sidebar-panel';
     public const PERMISSION_EDIT_CONTENT = 'llmify:edit-content';
     public const PERMISSION_EDIT_SITE = 'llmify:edit-site';
+    public const PERMISSION_VIEW_DASHBOARD = 'llmify:view-dashboard';
 
     // Random
     public const HEADER_REFRESH = 'X-Llmify-Refresh-Request';

--- a/src/Llmify.php
+++ b/src/Llmify.php
@@ -33,6 +33,7 @@ use samuelreichor\llmify\behaviors\LlmifyChangedBehavior;
 use samuelreichor\llmify\fields\LlmifySettingsField;
 use samuelreichor\llmify\models\PluginSettings;
 use samuelreichor\llmify\services\BotDetectionService;
+use samuelreichor\llmify\services\DashboardService;
 use samuelreichor\llmify\services\FieldDiscoveryService;
 use samuelreichor\llmify\services\FrontMatterService;
 use samuelreichor\llmify\services\HelperService;
@@ -66,6 +67,7 @@ use yii\log\FileTarget;
  * @property-read RequestService $request
  * @property-read FrontMatterService $frontMatter
  * @property-read BotDetectionService $botDetection
+ * @property-read DashboardService $dashboard
  */
 class Llmify extends Plugin
 {
@@ -89,6 +91,7 @@ class Llmify extends Plugin
                 'request' => RequestService::class,
                 'frontMatter' => FrontMatterService::class,
                 'botDetection' => BotDetectionService::class,
+                'dashboard' => DashboardService::class,
             ],
         ];
     }
@@ -136,6 +139,10 @@ class Llmify extends Plugin
         $subNavs = [];
         $item = parent::getCpNavItem();
         $currentUser = Craft::$app->getUser()->getIdentity();
+
+        if ($currentUser->can(Constants::PERMISSION_VIEW_DASHBOARD)) {
+            $subNavs['dashboard'] = ['label' => 'Dashboard', 'url' => 'llmify/dashboard'];
+        }
 
         if ($currentUser->can(Constants::PERMISSION_EDIT_CONTENT)) {
             $subNavs['content'] = ['label' => 'Content', 'url' => 'llmify/content'];
@@ -289,6 +296,7 @@ class Llmify extends Plugin
             UrlManager::EVENT_REGISTER_CP_URL_RULES,
             function(RegisterUrlRulesEvent $event) {
                 $event->rules['llmify'] = 'llmify/content/redirect';
+                $event->rules['llmify/dashboard'] = 'llmify/dashboard/index';
                 $event->rules['llmify/content'] = 'llmify/content/index';
                 $event->rules['llmify/content/<sectionId:\d+>'] = 'llmify/content/edit-section';
                 $event->rules['llmify/content/save-section-settings'] = 'llmify/content/save-section-settings';
@@ -525,17 +533,20 @@ class Llmify extends Plugin
                 $event->permissions[] = [
                     'heading' => 'LLMify',
                     'permissions' => [
-                        Constants::PERMISSION_GENERATE => [
-                            'label' => 'Generate Markdown',
-                        ],
-                        Constants::PERMISSION_CLEAR => [
-                            'label' => 'Clear Markdown',
+                        Constants::PERMISSION_VIEW_DASHBOARD => [
+                            'label' => 'View Dashboard',
                         ],
                         Constants::PERMISSION_EDIT_CONTENT => [
                             'label' => 'Edit Content Settings',
                         ],
                         Constants::PERMISSION_EDIT_SITE => [
                             'label' => 'Edit Site Settings',
+                        ],
+                        Constants::PERMISSION_GENERATE => [
+                            'label' => 'Generate Markdown',
+                        ],
+                        Constants::PERMISSION_CLEAR => [
+                            'label' => 'Clear Markdown',
                         ],
                         Constants::PERMISSION_VIEW_SIDEBAR_PANEL => [
                             'label' => 'View sidebar panel on element edit pages',

--- a/src/Llmify.php
+++ b/src/Llmify.php
@@ -169,7 +169,35 @@ class Llmify extends Plugin
             $this->_settings = $this->createSettingsModel() ?: false;
         }
 
+        if ($this->_settings instanceof PluginSettings) {
+            $overrides = self::getTestOverrides();
+            if (!empty($overrides['pluginSettings'])) {
+                $this->_settings->setAttributes($overrides['pluginSettings'], false);
+            }
+        }
+
         return $this->_settings ?: null;
+    }
+
+    /**
+     * Read test settings overrides from temp file (used by the llmify-testing module).
+     * Returns null when no override file exists (production/normal usage).
+     */
+    public static function getTestOverrides(): ?array
+    {
+        static $loaded = false;
+        static $data = null;
+
+        if (!$loaded) {
+            $loaded = true;
+            $path = sys_get_temp_dir() . '/llmify-test-overrides.json';
+            if (file_exists($path)) {
+                $content = file_get_contents($path);
+                $data = $content ? json_decode($content, true) : null;
+            }
+        }
+
+        return $data;
     }
 
     public function getSettingsResponse(): mixed

--- a/src/Llmify.php
+++ b/src/Llmify.php
@@ -13,6 +13,7 @@ use craft\events\ElementEvent;
 use craft\events\MoveElementEvent;
 use craft\events\MultiElementActionEvent;
 use craft\events\RegisterComponentTypesEvent;
+use craft\events\RegisterPreviewTargetsEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\RegisterUserPermissionsEvent;
 use craft\events\SectionEvent;
@@ -124,6 +125,7 @@ class Llmify extends Plugin
         if (Craft::$app->request->getIsCpRequest()) {
             $this->registerSettingEvents();
             $this->registerGeneralCpEvents();
+            $this->registerPreviewTargets();
 
             if (Craft::$app->edition === CmsEdition::Pro) {
                 $this->registerUserPermissionEvents();
@@ -326,6 +328,40 @@ class Llmify extends Plugin
                     $product = $event->sender;
                     $event->html .= $this->refresh->getSidebarHtml($product);
                 },
+            );
+        }
+    }
+
+    private function registerPreviewTargets(): void
+    {
+        Event::on(
+            Entry::class,
+            Element::EVENT_REGISTER_PREVIEW_TARGETS,
+            static function(RegisterPreviewTargetsEvent $event) {
+                /** @var Entry $entry */
+                $entry = $event->sender;
+                if ($entry->uri !== null) {
+                    $event->previewTargets[] = [
+                        'label' => '📄 ' . Craft::t('llmify', 'Markdown Preview'),
+                        'url' => HelperService::getMarkdownUrl($entry->uri, $entry->siteId),
+                    ];
+                }
+            }
+        );
+
+        if (HelperService::isCommerceInstalled()) {
+            Event::on(
+                \craft\commerce\elements\Product::class,
+                Element::EVENT_REGISTER_PREVIEW_TARGETS,
+                static function(RegisterPreviewTargetsEvent $event) {
+                    $product = $event->sender;
+                    if ($product->uri !== null) {
+                        $event->previewTargets[] = [
+                            'label' => '📄 ' . Craft::t('llmify', 'Markdown Preview'),
+                            'url' => HelperService::getMarkdownUrl($product->uri, $product->siteId),
+                        ];
+                    }
+                }
             );
         }
     }

--- a/src/Llmify.php
+++ b/src/Llmify.php
@@ -31,6 +31,7 @@ use putyourlightson\blitz\services\CacheRequestService;
 use samuelreichor\llmify\behaviors\LlmifyChangedBehavior;
 use samuelreichor\llmify\fields\LlmifySettingsField;
 use samuelreichor\llmify\models\PluginSettings;
+use samuelreichor\llmify\services\BotDetectionService;
 use samuelreichor\llmify\services\FrontMatterService;
 use samuelreichor\llmify\services\HelperService;
 use samuelreichor\llmify\services\LlmsService;
@@ -65,6 +66,7 @@ use yii\log\FileTarget;
  * @property-read RefreshService $refresh
  * @property-read RequestService $request
  * @property-read FrontMatterService $frontMatter
+ * @property-read BotDetectionService $botDetection
  */
 class Llmify extends Plugin
 {
@@ -86,6 +88,7 @@ class Llmify extends Plugin
                 'refresh' => RefreshService::class,
                 'request' => RequestService::class,
                 'frontMatter' => FrontMatterService::class,
+                'botDetection' => BotDetectionService::class,
             ],
         ];
     }
@@ -103,6 +106,7 @@ class Llmify extends Plugin
             if (Craft::$app->request->getIsSiteRequest()) {
                 $this->registerSiteEvents();
                 $this->registerAutoServeEvent();
+                $this->registerDiscoveryLinkTag();
             }
 
             if (Craft::$app->request->getIsCpRequest()) {
@@ -331,7 +335,8 @@ class Llmify extends Plugin
                         $response = Craft::$app->response;
                         $response->format = $response::FORMAT_RAW;
                         $response->headers->set('Content-Type', 'text/markdown; charset=UTF-8');
-                        $response->headers->set('Vary', 'Accept');
+                        $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
+                        $response->headers->set('Vary', 'Accept, User-Agent');
                     }
                 }
 
@@ -342,20 +347,15 @@ class Llmify extends Plugin
     }
 
     /**
-     * Tell Blitz to skip caching for text/markdown requests so our template event can handle them.
+     * Tell Blitz to skip caching for text/markdown or bot requests so our template event can handle them.
      */
     private function registerAutoServeEvent(): void
     {
-        if (!$this->getSettings()->autoServeMarkdown) {
-            return;
-        }
-
         if (Craft::$app->request->getIsConsoleRequest()) {
             return;
         }
 
-        $accept = Craft::$app->request->getHeaders()->get('Accept', '');
-        if (!str_contains($accept, 'text/markdown')) {
+        if (!$this->isAutoServeAble()) {
             return;
         }
 
@@ -371,8 +371,25 @@ class Llmify extends Plugin
 
     private function isAutoServeAble(): bool
     {
+        if (Craft::$app->request->getIsConsoleRequest()) {
+            return false;
+        }
+
+        $settings = $this->getSettings();
+
         $accept = Craft::$app->request->getHeaders()->get('Accept', '');
-        return $this->getSettings()->autoServeMarkdown && str_contains($accept, 'text/markdown');
+        if ($settings->autoServeMarkdown && str_contains($accept, 'text/markdown')) {
+            return true;
+        }
+
+        if ($settings->enableBotDetection) {
+            $userAgent = Craft::$app->request->getHeaders()->get('User-Agent', '');
+            if ($this->botDetection->isAiBot($userAgent)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function registerElementChangeEvents(): void
@@ -433,6 +450,44 @@ class Llmify extends Plugin
 
                 $mdPrefix = $this->getSettings()->markdownUrlPrefix;
                 $event->rules[$mdPrefix . '/<slug:.*\.md>'] = 'llmify/file/generate-page-md';
+            }
+        );
+    }
+
+    private function registerDiscoveryLinkTag(): void
+    {
+        if (!$this->getSettings()->autoInjectDiscoveryTag) {
+            return;
+        }
+
+        $registered = false;
+
+        Event::on(
+            View::class,
+            View::EVENT_BEFORE_RENDER_TEMPLATE,
+            function(TemplateEvent $event) use (&$registered) {
+                if ($registered || $event->templateMode !== 'site') {
+                    return;
+                }
+
+                $registered = true;
+
+                /** @var UrlManager $urlManager */
+                $urlManager = Craft::$app->getUrlManager();
+                $element = $urlManager->getMatchedElement();
+
+                if (!$element || !$element->uri) {
+                    return;
+                }
+
+                if ($this->refresh->canRefreshElement($element)) {
+                    $markdownUrl = HelperService::getMarkdownUrl($element->uri, $element->siteId);
+                    Craft::$app->view->registerLinkTag([
+                        'rel' => 'alternate',
+                        'type' => 'text/markdown',
+                        'href' => $markdownUrl,
+                    ], 'llmify-alternate');
+                }
             }
         );
     }

--- a/src/Llmify.php
+++ b/src/Llmify.php
@@ -18,6 +18,7 @@ use craft\events\RegisterUserPermissionsEvent;
 use craft\events\SectionEvent;
 use craft\events\SiteEvent;
 use craft\events\TemplateEvent;
+use craft\helpers\UrlHelper;
 use craft\services\Elements;
 use craft\services\Entries;
 use craft\services\Fields;
@@ -43,11 +44,7 @@ use samuelreichor\llmify\services\SettingsService;
 use samuelreichor\llmify\twig\LlmifyExtension;
 use samuelreichor\llmify\utilities\Utils;
 use Throwable;
-use Twig\Error\LoaderError;
-use Twig\Error\RuntimeError;
-use Twig\Error\SyntaxError;
 use yii\base\Event;
-use yii\base\Exception;
 use yii\log\FileTarget;
 
 /**
@@ -145,14 +142,12 @@ class Llmify extends Plugin
             $subNavs['globals'] = ['label' => 'Site', 'url' => 'llmify/globals'];
         }
 
-        if (empty($subNavs)) {
-            return null;
+        if ($currentUser->admin && Craft::$app->getConfig()->getGeneral()->allowAdminChanges) {
+            $subNavs['settings'] = ['label' => 'Settings', 'url' => 'llmify/settings'];
         }
 
-        if (count($subNavs) <= 1) {
-            return array_merge($item, [
-                'subnav' => [],
-            ]);
+        if (empty($subNavs)) {
+            return null;
         }
 
         return array_merge($item, [
@@ -177,19 +172,9 @@ class Llmify extends Plugin
         return $this->_settings ?: null;
     }
 
-    /**
-     * @throws SyntaxError
-     * @throws RuntimeError
-     * @throws Exception
-     * @throws LoaderError
-     */
-    protected function settingsHtml(): string
+    public function getSettingsResponse(): mixed
     {
-        return Craft::$app->view->renderTemplate('llmify/settings/plugin/index', [
-            'plugin' => $this,
-            'settings' => $this->getSettings(),
-            'readOnly' => !Craft::$app->getConfig()->getGeneral()->allowAdminChanges,
-        ]);
+        return Craft::$app->getResponse()->redirect(UrlHelper::cpUrl('llmify/settings'));
     }
 
     private function registerSettingEvents(): void
@@ -278,6 +263,8 @@ class Llmify extends Plugin
                 $event->rules['llmify/content/save-section-settings'] = 'llmify/content/save-section-settings';
                 $event->rules['llmify/globals'] = 'llmify/globals/index';
                 $event->rules['llmify/globals/save-settings'] = 'llmify/globals/save-settings';
+                $event->rules['llmify/settings'] = 'llmify/settings/index';
+                $event->rules['llmify/settings/save-settings'] = 'llmify/settings/save-settings';
             }
         );
 

--- a/src/Llmify.php
+++ b/src/Llmify.php
@@ -464,7 +464,8 @@ class Llmify extends Plugin
                 $event->rules['llms-full.txt'] = 'llmify/file/generate-llms-full-txt';
 
                 $mdPrefix = $this->getSettings()->markdownUrlPrefix;
-                $event->rules[$mdPrefix . '/<slug:.*\.md>'] = 'llmify/file/generate-page-md';
+                $mdRoute = $mdPrefix !== '' ? $mdPrefix . '/<slug:.*\.md>' : '<slug:.*\.md>';
+                $event->rules[$mdRoute] = 'llmify/file/generate-page-md';
             }
         );
     }

--- a/src/Llmify.php
+++ b/src/Llmify.php
@@ -428,6 +428,7 @@ class Llmify extends Plugin
             UrlManager::EVENT_REGISTER_SITE_URL_RULES,
             function(RegisterUrlRulesEvent $event) {
                 $event->rules['llms.txt'] = 'llmify/file/generate-llms-txt';
+                $event->rules['.well-known/llms.txt'] = 'llmify/file/generate-llms-txt';
                 $event->rules['llms-full.txt'] = 'llmify/file/generate-llms-full-txt';
 
                 $mdPrefix = $this->getSettings()->markdownUrlPrefix;

--- a/src/Llmify.php
+++ b/src/Llmify.php
@@ -33,6 +33,7 @@ use samuelreichor\llmify\behaviors\LlmifyChangedBehavior;
 use samuelreichor\llmify\fields\LlmifySettingsField;
 use samuelreichor\llmify\models\PluginSettings;
 use samuelreichor\llmify\services\BotDetectionService;
+use samuelreichor\llmify\services\FieldDiscoveryService;
 use samuelreichor\llmify\services\FrontMatterService;
 use samuelreichor\llmify\services\HelperService;
 use samuelreichor\llmify\services\LlmsService;
@@ -60,6 +61,7 @@ use yii\log\FileTarget;
  * @property-read SettingsService $settings
  * @property-read MetadataService $metadata
  * @property-read HelperService $helper
+ * @property-read FieldDiscoveryService $fieldDiscovery
  * @property-read RefreshService $refresh
  * @property-read RequestService $request
  * @property-read FrontMatterService $frontMatter
@@ -82,6 +84,7 @@ class Llmify extends Plugin
                 'settings' => SettingsService::class,
                 'metadata' => MetadataService::class,
                 'helper' => HelperService::class,
+                'fieldDiscovery' => FieldDiscoveryService::class,
                 'refresh' => RefreshService::class,
                 'request' => RequestService::class,
                 'frontMatter' => FrontMatterService::class,

--- a/src/controllers/ContentController.php
+++ b/src/controllers/ContentController.php
@@ -80,8 +80,8 @@ class ContentController extends Controller
 
         $elementType = Craft::$app->getRequest()->getQueryParam('elementType', Entry::class);
         $contentSettings = Llmify::getInstance()->settings;
-        $helperService = Llmify::getInstance()->helper;
-        $currentSiteId = $helperService->getCurrentCpSiteId();
+        $currentSiteId = Llmify::getInstance()->helper->getCurrentCpSiteId();
+        $fieldDiscovery = Llmify::getInstance()->fieldDiscovery;
 
         $sectionSettings = $contentSettings->getContentSetting($sectionId, $currentSiteId, $elementType);
 
@@ -92,13 +92,13 @@ class ContentController extends Controller
         if ($elementType === Entry::class) {
             $section = Craft::$app->entries->getSectionById($sectionId);
             $groupName = $section ? $section->name : '';
-            $textFieldOptions = $section ? $helperService->getTextFieldsForSection($section) : [];
-            $frontMatterFieldOptions = $section ? $helperService->getFrontMatterFieldOptions($section) : [];
+            $textFieldOptions = $section ? $fieldDiscovery->getSourceOptions($section) : [];
+            $frontMatterFieldOptions = $section ? $fieldDiscovery->getFrontMatterOptions($section) : [];
         } elseif (HelperService::isCommerceInstalled() && $elementType === \craft\commerce\elements\Product::class) {
             $productType = \craft\commerce\Plugin::getInstance()->getProductTypes()->getProductTypeById($sectionId);
             $groupName = $productType ? $productType->name : '';
-            $textFieldOptions = $productType ? $helperService->getTextFieldsForProductType($productType) : [];
-            $frontMatterFieldOptions = $productType ? $helperService->getFrontMatterFieldOptions(null, null, $productType) : [];
+            $textFieldOptions = $productType ? $fieldDiscovery->getSourceOptions($productType) : [];
+            $frontMatterFieldOptions = $productType ? $fieldDiscovery->getFrontMatterOptions(null, null, $productType) : [];
         }
 
         // Get inherited front matter fields from site settings

--- a/src/controllers/ContentController.php
+++ b/src/controllers/ContentController.php
@@ -7,6 +7,7 @@ use craft\elements\Entry;
 use craft\errors\SiteNotFoundException;
 use craft\helpers\UrlHelper;
 use craft\web\Controller;
+use samuelreichor\llmify\Constants;
 use samuelreichor\llmify\Llmify;
 use samuelreichor\llmify\models\ContentSettings;
 use samuelreichor\llmify\services\HelperService;
@@ -163,8 +164,12 @@ class ContentController extends Controller
 
     public function actionRedirect(): Response
     {
-        // As there is no dashboard we simply redirect to content
-        $targetUrl = UrlHelper::cpUrl('llmify/content');
-        return $this->redirect($targetUrl);
+        $currentUser = Craft::$app->getUser()->getIdentity();
+
+        if ($currentUser->can(Constants::PERMISSION_VIEW_DASHBOARD)) {
+            return $this->redirect(UrlHelper::cpUrl('llmify/dashboard'));
+        }
+
+        return $this->redirect(UrlHelper::cpUrl('llmify/content'));
     }
 }

--- a/src/controllers/DashboardController.php
+++ b/src/controllers/DashboardController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace samuelreichor\llmify\controllers;
+
+use craft\web\Controller;
+use samuelreichor\llmify\Llmify;
+use samuelreichor\llmify\services\PermissionService;
+use yii\web\Response;
+
+class DashboardController extends Controller
+{
+    public function actionIndex(): Response
+    {
+        PermissionService::requireViewDashboard();
+
+        $dashboard = Llmify::getInstance()->dashboard;
+        $currentSiteId = Llmify::getInstance()->helper->getCurrentCpSiteId();
+
+        return $this->renderTemplate('llmify/settings/dashboard/index', [
+            'currentSiteId' => $currentSiteId,
+            'pluginChecks' => $dashboard->getPluginSettingsChecks(),
+            'siteSetup' => $dashboard->getSiteSetupData($currentSiteId),
+            'contentSetup' => $dashboard->getContentSetupData($currentSiteId),
+            'generationStats' => $dashboard->getGenerationStats($currentSiteId),
+        ]);
+    }
+}

--- a/src/controllers/FileController.php
+++ b/src/controllers/FileController.php
@@ -22,6 +22,7 @@ class FileController extends Controller
         }
 
         Craft::$app->response->headers->set('X-Robots-Tag', 'noindex, nofollow');
+        Craft::$app->response->headers->set('Vary', 'Accept');
 
         return true;
     }

--- a/src/controllers/GlobalsController.php
+++ b/src/controllers/GlobalsController.php
@@ -27,7 +27,7 @@ class GlobalsController extends Controller
         $currentSiteId = Llmify::getInstance()->helper->getCurrentCpSiteId();
         $globalSettings = Llmify::getInstance()->settings;
         $settings = $globalSettings->getGlobalSetting($currentSiteId);
-        $frontMatterFieldOptions = Llmify::getInstance()->helper->getFrontMatterFieldOptions();
+        $frontMatterFieldOptions = Llmify::getInstance()->fieldDiscovery->getFrontMatterOptions();
 
         return $this->renderTemplate('llmify/settings/globals/index', [
             'settings' => $settings,

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace samuelreichor\llmify\controllers;
+
+use Craft;
+use craft\web\Controller;
+use samuelreichor\llmify\Llmify;
+use yii\web\Response;
+
+class SettingsController extends Controller
+{
+    protected array|bool|int $allowAnonymous = false;
+
+    public function actionIndex(): Response
+    {
+        $this->requireAdmin();
+
+        return $this->renderTemplate('llmify/settings/index', [
+            'plugin' => Llmify::getInstance(),
+            'settings' => Llmify::getInstance()->getSettings(),
+            'readOnly' => !Craft::$app->getConfig()->getGeneral()->allowAdminChanges,
+        ]);
+    }
+
+    public function actionSaveSettings(): ?Response
+    {
+        $this->requirePostRequest();
+        $this->requireAdmin();
+
+        $plugin = Llmify::getInstance();
+        $posted = $this->request->getBodyParam('settings', []);
+
+        $settings = array_merge($plugin->getSettings()->toArray(), $posted);
+
+        if (!Craft::$app->getPlugins()->savePluginSettings($plugin, $settings)) {
+            Craft::$app->getSession()->setError('Couldn\'t save plugin settings.');
+
+            return null;
+        }
+
+        Craft::$app->getSession()->setNotice('Plugin settings saved.');
+
+        return $this->redirectToPostedUrl();
+    }
+}

--- a/src/fields/LlmifySettingsField.php
+++ b/src/fields/LlmifySettingsField.php
@@ -64,13 +64,13 @@ class LlmifySettingsField extends Field
         }
 
         $view = Craft::$app->getView();
-        $helperService = Llmify::getInstance()->helper;
-        $textFieldOptions = $helperService->getTextFieldsForElement($element);
+        $fieldDiscovery = Llmify::getInstance()->fieldDiscovery;
+        $textFieldOptions = $fieldDiscovery->getSourceOptions($isEntry ? $element : $element->getType());
 
         if ($isEntry) {
-            $frontMatterFieldOptions = $helperService->getFrontMatterFieldOptions(null, $element);
+            $frontMatterFieldOptions = $fieldDiscovery->getFrontMatterOptions(null, $element);
         } else {
-            $frontMatterFieldOptions = $helperService->getFrontMatterFieldOptions(null, null, $element->getType());
+            $frontMatterFieldOptions = $fieldDiscovery->getFrontMatterOptions(null, null, $element->getType());
         }
 
         $metaDataService = new MetaDataService($element);

--- a/src/models/PluginSettings.php
+++ b/src/models/PluginSettings.php
@@ -8,7 +8,7 @@ class PluginSettings extends Model
 {
     public bool $isEnabled = true;
     public bool $isRealUrlLlm = false;
-    public bool $autoServeMarkdown = false;
+    public bool $autoServeMarkdown = true;
     public string $markdownUrlPrefix = 'raw';
     public int $concurrentRequests = 3;
     public int $requestTimeout = 100;
@@ -22,6 +22,9 @@ class PluginSettings extends Model
             'classes' => 'exclude-llmify',
         ],
     ];
+    public bool $autoInjectDiscoveryTag = true;
+    public bool $enableBotDetection = true;
+    public array $additionalBotUserAgents = [];
     public bool $frontMatterInFullTxt = false;
 
     public function defineRules(): array

--- a/src/models/PluginSettings.php
+++ b/src/models/PluginSettings.php
@@ -32,7 +32,6 @@ class PluginSettings extends Model
         return [
             [
                 [
-                    'markdownUrlPrefix',
                     'concurrentRequests',
                     'requestTimeout',
                 ], 'required',

--- a/src/models/PluginSettings.php
+++ b/src/models/PluginSettings.php
@@ -15,7 +15,7 @@ class PluginSettings extends Model
     public array $markdownConfig = [
         'strip_tags' => true,
         'header_style' => 'atx',
-        'remove_nodes' => 'img picture style form button input select option svg script nav noscript',
+        'remove_nodes' => 'img picture style form button input select option svg script nav noscript video audio source',
     ];
     public array $excludeClasses = [
         [

--- a/src/services/BotDetectionService.php
+++ b/src/services/BotDetectionService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace samuelreichor\llmify\services;
+
+use craft\base\Component;
+use samuelreichor\llmify\Llmify;
+
+class BotDetectionService extends Component
+{
+    public const DEFAULT_BOTS = [
+        'GPTBot',
+        'ClaudeBot',
+        'ChatGPT-User',
+        'Amazonbot',
+        'Bytespider',
+        'CCBot',
+        'Google-Extended',
+        'FacebookBot',
+        'PerplexityBot',
+        'Applebot-Extended',
+        'cohere-ai',
+        'OAI-SearchBot',
+        'Claude-Web',
+    ];
+
+    public function isAiBot(string $userAgent): bool
+    {
+        return $this->getDetectedBotName($userAgent) !== null;
+    }
+
+    public function getDetectedBotName(string $userAgent): ?string
+    {
+        $customBots = array_map(
+            fn($row) => $row['userAgent'] ?? '',
+            Llmify::getInstance()->getSettings()->additionalBotUserAgents
+        );
+
+        $allBots = array_merge(self::DEFAULT_BOTS, array_filter($customBots));
+
+        foreach ($allBots as $bot) {
+            if (stripos($userAgent, $bot) !== false) {
+                return $bot;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/services/DashboardService.php
+++ b/src/services/DashboardService.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace samuelreichor\llmify\services;
+
+use Craft;
+use craft\base\Component;
+use craft\db\Query as DbQuery;
+use craft\elements\Entry;
+use craft\helpers\UrlHelper;
+use samuelreichor\llmify\Constants;
+use samuelreichor\llmify\Llmify;
+use yii\base\InvalidConfigException;
+use yii\db\Exception;
+
+class DashboardService extends Component
+{
+    /**
+     * Get site setup data for a single site.
+     *
+     * Returns check results and a score (0-100) for the site-level configuration.
+     *
+     * @return array{
+     *     checks: array<int, array{label: string, ok: bool, detail: string}>,
+     *     score: float,
+     * }
+     * @throws Exception
+     */
+    public function getSiteSetupData(int $siteId): array
+    {
+        $globalSettings = Llmify::getInstance()->settings->getGlobalSetting($siteId);
+
+        $enabledFrontMatter = array_filter(
+            $globalSettings->frontMatterFields,
+            fn($field) => !empty($field['enabled']),
+        );
+
+        $checks = [
+            [
+                'label' => 'LLMify enabled',
+                'ok' => $globalSettings->enabled,
+                'detail' => '',
+            ],
+            [
+                'label' => 'LLM Title',
+                'ok' => $globalSettings->llmTitle !== '',
+                'detail' => $globalSettings->llmTitle !== '' ? $this->truncate($globalSettings->llmTitle, 50) : '',
+            ],
+            [
+                'label' => 'LLM Description',
+                'ok' => $globalSettings->llmDescription !== '',
+                'detail' => $globalSettings->llmDescription !== '' ? $this->truncate($globalSettings->llmDescription, 50) : '',
+            ],
+            [
+                'label' => 'LLM Note',
+                'ok' => $globalSettings->llmNote !== '',
+                'detail' => $globalSettings->llmNote !== '' ? $this->truncate($globalSettings->llmNote, 50) : '',
+            ],
+            [
+                'label' => 'Front Matter Fields',
+                'ok' => count($enabledFrontMatter) > 0,
+                'detail' => count($enabledFrontMatter) . '/' . count($globalSettings->frontMatterFields) . ' active',
+            ],
+        ];
+
+        $passed = count(array_filter($checks, fn($c) => $c['ok']));
+        $score = round(($passed / count($checks)) * 100);
+
+        return [
+            'checks' => $checks,
+            'score' => $score,
+        ];
+    }
+
+    /**
+     * Get content setup data for a single site.
+     *
+     * Returns per-section check results and an overall score.
+     *
+     * @return array{
+     *     sections: array<int, array{
+     *         groupName: string,
+     *         groupType: string,
+     *         elementCount: int,
+     *         editUrl: string,
+     *         checks: array{enabled: bool, hasTitle: bool, hasDescription: bool, hasSectionTitle: bool, hasSectionDescription: bool},
+     *     }>,
+     *     score: float,
+     * }
+     * @throws InvalidConfigException
+     */
+    public function getContentSetupData(int $siteId): array
+    {
+        $contentSettings = Llmify::getInstance()->settings->getContentSettingsBySiteId($siteId);
+        $sections = [];
+        $totalChecks = 0;
+        $passedChecks = 0;
+
+        foreach ($contentSettings as $setting) {
+            $groupName = null;
+            $groupType = null;
+            $elementCount = 0;
+
+            if ($setting->elementType === Entry::class) {
+                $section = Craft::$app->entries->getSectionById($setting->groupId);
+                if ($section) {
+                    $groupName = $section->name;
+                    $groupType = ucfirst($section->type);
+                }
+            } elseif (HelperService::isCommerceInstalled() && $setting->elementType === \craft\commerce\elements\Product::class) {
+                $productType = \craft\commerce\Plugin::getInstance()->getProductTypes()->getProductTypeById($setting->groupId);
+                if ($productType) {
+                    $groupName = $productType->name;
+                    $groupType = 'Product';
+                }
+            }
+
+            if (!$groupName) {
+                continue;
+            }
+
+            if ($setting->enabled) {
+                $query = $setting->elementType === Entry::class
+                    ? Entry::find()->sectionId($setting->groupId)->siteId($siteId)->status('enabled')
+                    : \craft\commerce\elements\Product::find()->typeId($setting->groupId)->siteId($siteId)->status('enabled');
+                $elementCount = (int)$query->count();
+            }
+
+            $hasTitle = $setting->llmTitleSource !== 'custom' || $setting->llmTitle !== '';
+            $hasDescription = $setting->llmDescriptionSource !== 'custom' || $setting->llmDescription !== '';
+            $hasSectionTitle = $setting->llmSectionTitle !== '';
+            $hasSectionDescription = $setting->llmSectionDescription !== '';
+
+            // Score: only count enabled sections
+            if ($setting->enabled) {
+                $sectionCheckCount = 4; // title, desc, sectionTitle, sectionDesc
+                $sectionPassed = (int)$hasTitle + (int)$hasDescription + (int)$hasSectionTitle + (int)$hasSectionDescription;
+                $totalChecks += $sectionCheckCount;
+                $passedChecks += $sectionPassed;
+            }
+
+            $sections[] = [
+                'groupName' => $groupName,
+                'groupType' => $groupType,
+                'elementCount' => $elementCount,
+                'editUrl' => UrlHelper::cpUrl('llmify/content/' . $setting->groupId, ['elementType' => $setting->elementType]),
+                'checks' => [
+                    'enabled' => $setting->enabled,
+                    'hasTitle' => $hasTitle,
+                    'hasDescription' => $hasDescription,
+                    'hasSectionTitle' => $hasSectionTitle,
+                    'hasSectionDescription' => $hasSectionDescription,
+                ],
+            ];
+        }
+
+        $score = $totalChecks > 0 ? round(($passedChecks / $totalChecks) * 100) : 0;
+
+        return [
+            'sections' => $sections,
+            'score' => $score,
+        ];
+    }
+
+    /**
+     * Get generation statistics for a single site.
+     *
+     * @return array{
+     *     totalElements: int,
+     *     totalPages: int,
+     *     coveragePercent: float,
+     *     lastRefresh: string|null,
+     *     oldestPage: string|null,
+     *     avgContentLength: int,
+     *     avgTokens: int,
+     * }
+     */
+    public function getGenerationStats(int $siteId): array
+    {
+        $contentSettings = Llmify::getInstance()->settings->getContentSettingsBySiteId($siteId);
+
+        $totalElements = 0;
+        foreach ($contentSettings as $setting) {
+            if (!$setting->enabled) {
+                continue;
+            }
+
+            if ($setting->elementType === Entry::class) {
+                $totalElements += (int)Entry::find()
+                    ->sectionId($setting->groupId)
+                    ->siteId($siteId)
+                    ->status('enabled')
+                    ->count();
+            } elseif (HelperService::isCommerceInstalled() && $setting->elementType === \craft\commerce\elements\Product::class) {
+                $totalElements += (int)\craft\commerce\elements\Product::find()
+                    ->typeId($setting->groupId)
+                    ->siteId($siteId)
+                    ->status('enabled')
+                    ->count();
+            }
+        }
+
+        $pageStats = (new DbQuery())
+            ->select([
+                'COUNT(*) as totalPages',
+                'MAX([[dateUpdated]]) as lastRefresh',
+                'MIN([[dateUpdated]]) as oldestPage',
+                'AVG(LENGTH([[content]])) as avgContentLength',
+            ])
+            ->from([Constants::TABLE_PAGES])
+            ->where(['siteId' => $siteId])
+            ->one();
+
+        $totalPages = (int)($pageStats['totalPages'] ?? 0);
+        $coveragePercent = $totalElements > 0
+            ? round(($totalPages / $totalElements) * 100, 1)
+            : 0;
+
+        return [
+            'totalElements' => $totalElements,
+            'totalPages' => $totalPages,
+            'coveragePercent' => min($coveragePercent, 100),
+            'lastRefresh' => $pageStats['lastRefresh'] ?? null,
+            'oldestPage' => $pageStats['oldestPage'] ?? null,
+            'avgContentLength' => (int)($pageStats['avgContentLength'] ?? 0),
+            'avgTokens' => (int)(($pageStats['avgContentLength'] ?? 0) / 4),
+        ];
+    }
+
+    /**
+     * Get plugin settings checks for the top bar.
+     *
+     * @return array{
+     *     isEnabled: bool,
+     *     markdownUrlPrefix: string,
+     *     botDetection: bool,
+     *     discoveryTag: bool,
+     *     autoServe: bool,
+     *     excludeClasses: string[],
+     * }
+     */
+    public function getPluginSettingsChecks(): array
+    {
+        $settings = Llmify::getInstance()->getSettings();
+
+        $excludeClassNames = array_map(
+            fn($item) => $item['classes'] ?? '',
+            $settings->excludeClasses,
+        );
+
+        return [
+            'isEnabled' => $settings->isEnabled,
+            'markdownUrlPrefix' => $settings->markdownUrlPrefix,
+            'botDetection' => $settings->enableBotDetection,
+            'discoveryTag' => $settings->autoInjectDiscoveryTag,
+            'autoServe' => $settings->autoServeMarkdown,
+            'excludeClasses' => array_filter($excludeClassNames),
+        ];
+    }
+
+    private function truncate(string $text, int $length): string
+    {
+        if (mb_strlen($text) <= $length) {
+            return $text;
+        }
+
+        return mb_substr($text, 0, $length) . '...';
+    }
+}

--- a/src/services/FieldDiscoveryService.php
+++ b/src/services/FieldDiscoveryService.php
@@ -299,6 +299,8 @@ class FieldDiscoveryService extends Component
 
         /** @var \nystudio107\seomatic\Seomatic $seomatic */
         $seomatic = \nystudio107\seomatic\Seomatic::$plugin;
+        // Reset preview flag so SEOmatic reloads containers for each element
+        \nystudio107\seomatic\Seomatic::$previewingMetaContainers = false;
         $seomatic->metaContainers->previewMetaContainers($uri, (int)$element->siteId, true, true, $element);
         $seomatic->metaContainers->parseGlobalVars();
 

--- a/src/services/FieldDiscoveryService.php
+++ b/src/services/FieldDiscoveryService.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace samuelreichor\llmify\services;
+
+use Craft;
+use craft\base\Component;
+use craft\base\ElementInterface;
+use craft\elements\Entry;
+use craft\fields\ContentBlock;
+use craft\fields\PlainText;
+use craft\models\EntryType;
+use craft\models\FieldLayout;
+use craft\models\Section;
+
+class FieldDiscoveryService extends Component
+{
+    private const SEOMATIC_CLASS = 'nystudio107\seomatic\Seomatic';
+
+    private const SOURCE_OPTION_BASE = [
+        [
+            'label' => 'Custom Text',
+            'value' => 'custom',
+        ],
+        [
+            'label' => '--- Fields ---',
+            'disabled' => true,
+        ],
+        [
+            'label' => 'Title',
+            'value' => 'title',
+        ],
+    ];
+
+    /**
+     * Get source options for title/description dropdowns.
+     *
+     * @param Section|Entry|\craft\commerce\models\ProductType $context
+     * @return array<int, array{label: string, value?: string, disabled?: bool}>
+     */
+    public function getSourceOptions(object $context): array
+    {
+        if ($context instanceof Entry) {
+            return $this->getSourceOptionsForEntryTypes([$context->type]);
+        }
+
+        if ($context instanceof Section) {
+            return $this->getSourceOptionsForEntryTypes($context->getEntryTypes());
+        }
+
+        // Commerce Product Type
+        return $this->getSourceOptionsForProductType($context);
+    }
+
+    /**
+     * Get options for front matter field dropdowns.
+     *
+     * @param \craft\commerce\models\ProductType|null $productType
+     * @return array<int, array{label: string, value?: string, disabled?: bool}>
+     */
+    public function getFrontMatterOptions(?Section $section = null, ?Entry $entry = null, ?object $productType = null): array
+    {
+        $options = [
+            ['label' => '--- Built-in Fields ---', 'disabled' => true],
+            ['label' => 'Title', 'value' => 'builtin:title'],
+            ['label' => 'Description', 'value' => 'builtin:description'],
+            ['label' => 'URL', 'value' => 'builtin:url'],
+            ['label' => 'URI', 'value' => 'builtin:uri'],
+            ['label' => 'Date Modified', 'value' => 'builtin:date_modified'],
+            ['label' => 'Date Created', 'value' => 'builtin:date_created'],
+            ['label' => 'Section', 'value' => 'builtin:section'],
+            ['label' => 'Entry Type', 'value' => 'builtin:entry_type'],
+            ['label' => 'Author', 'value' => 'builtin:author'],
+        ];
+
+        if ($productType !== null) {
+            $fieldLayout = $productType->getFieldLayout();
+            $textFields = $this->getTextFieldsFromLayout($fieldLayout);
+            if (!empty($textFields)) {
+                $options[] = ['label' => '--- Product Fields ---', 'disabled' => true];
+                foreach ($textFields as $field) {
+                    $options[] = [
+                        'label' => $field['label'],
+                        'value' => 'field:' . $field['value'],
+                    ];
+                }
+            }
+
+            return $this->appendSeoOptions($options);
+        }
+
+        $entryTypes = [];
+        if ($entry !== null) {
+            $entryTypes = [$entry->type];
+        } elseif ($section !== null) {
+            $entryTypes = $section->getEntryTypes();
+        }
+
+        if (!empty($entryTypes)) {
+            $textFields = $this->getCommonTextFields($entryTypes);
+            $contentBlockFields = $this->getContentBlockFields($entryTypes);
+
+            if (!empty($textFields)) {
+                $options[] = ['label' => '--- Entry Fields ---', 'disabled' => true];
+                foreach ($textFields as $field) {
+                    $options[] = [
+                        'label' => $field['label'],
+                        'value' => 'field:' . $field['value'],
+                    ];
+                }
+            }
+
+            if (!empty($contentBlockFields)) {
+                $options[] = ['label' => '--- Content Blocks ---', 'disabled' => true];
+                foreach ($contentBlockFields as $field) {
+                    $options[] = [
+                        'label' => $field['label'],
+                        'value' => 'field:' . $field['value'],
+                    ];
+                }
+            }
+        }
+
+        return $this->appendSeoOptions($options);
+    }
+
+    /**
+     * @param EntryType[] $entryTypes
+     */
+    private function getSourceOptionsForEntryTypes(array $entryTypes): array
+    {
+        $textFields = $this->getCommonTextFields($entryTypes);
+        $contentBlockFields = $this->getContentBlockFields($entryTypes);
+
+        $result = array_merge(self::SOURCE_OPTION_BASE, $textFields);
+
+        if (!empty($contentBlockFields)) {
+            $result[] = ['label' => '--- Content Blocks ---', 'disabled' => true];
+            $result = array_merge($result, $contentBlockFields);
+        }
+
+        return $this->appendSeoOptions($result);
+    }
+
+    /**
+     * @param \craft\commerce\models\ProductType $productType
+     */
+    private function getSourceOptionsForProductType(object $productType): array
+    {
+        $fieldLayout = $productType->getFieldLayout();
+        $textFields = $this->getTextFieldsFromLayout($fieldLayout);
+        $result = array_merge(self::SOURCE_OPTION_BASE, $textFields);
+
+        return $this->appendSeoOptions($result);
+    }
+
+    /**
+     * @return array<int, array{label: string, value: string}>
+     */
+    private function getTextFieldsFromLayout(FieldLayout $layout): array
+    {
+        $textFields = [];
+        foreach ($layout->getCustomFields() as $field) {
+            if ($this->isTextField($field)) {
+                $textFields[] = [
+                    'label' => $field->name,
+                    'value' => $field->handle,
+                ];
+            }
+        }
+
+        return $textFields;
+    }
+
+    /**
+     * @param EntryType[] $entryTypes
+     * @return array<int, array{label: string, value: string}>
+     */
+    private function getCommonTextFields(array $entryTypes): array
+    {
+        if (empty($entryTypes)) {
+            return [];
+        }
+
+        $allFieldHandles = [];
+        foreach ($entryTypes as $entryType) {
+            $textFields = array_filter($entryType->getCustomFields(), fn($field) => $this->isTextField($field));
+            $allFieldHandles[] = array_map(fn($field) => $field->handle, $textFields);
+        }
+
+        $commonHandles = array_intersect(...$allFieldHandles);
+        $result = [];
+
+        foreach ($commonHandles as $handle) {
+            $field = Craft::$app->fields->getFieldByHandle($handle);
+            if ($field) {
+                $result[] = [
+                    'label' => $field->name,
+                    'value' => $field->handle,
+                ];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param EntryType[] $entryTypes
+     * @return array<int, array{label: string, value: string}>
+     */
+    private function getContentBlockFields(array $entryTypes): array
+    {
+        if (empty($entryTypes) || !class_exists(ContentBlock::class)) {
+            return [];
+        }
+
+        $allContentBlockFields = [];
+
+        foreach ($entryTypes as $entryType) {
+            $contentBlockFieldsInType = [];
+
+            foreach ($entryType->getCustomFields() as $field) {
+                if (!$field instanceof ContentBlock) {
+                    continue;
+                }
+
+                foreach ($field->getFieldLayout()->getCustomFields() as $nestedField) {
+                    if ($this->isTextField($nestedField)) {
+                        $key = $field->handle . '.' . $nestedField->handle;
+                        $contentBlockFieldsInType[$key] = [
+                            'contentBlockName' => $field->name,
+                            'fieldName' => $nestedField->name,
+                        ];
+                    }
+                }
+            }
+
+            $allContentBlockFields[] = $contentBlockFieldsInType;
+        }
+
+        if (count($allContentBlockFields) === 1) {
+            $commonKeys = array_keys($allContentBlockFields[0]);
+        } else {
+            $commonKeys = array_keys(array_intersect_key(...$allContentBlockFields));
+        }
+
+        $result = [];
+        foreach ($commonKeys as $key) {
+            $info = $allContentBlockFields[0][$key];
+            $result[] = [
+                'label' => $info['contentBlockName'] . ' › ' . $info['fieldName'],
+                'value' => $key,
+            ];
+        }
+
+        return $result;
+    }
+
+    private function appendSeoOptions(array $options): array
+    {
+        if (!class_exists(self::SEOMATIC_CLASS)) {
+            return $options;
+        }
+
+        $options[] = ['label' => '--- SEOMatic Fields ---', 'disabled' => true];
+        $options[] = ['label' => 'SEO Title', 'value' => 'seomatic:seoTitle'];
+        $options[] = ['label' => 'SEO Description', 'value' => 'seomatic:seoDescription'];
+
+        return $options;
+    }
+
+    /**
+     * Resolve a parsed SEO value (seoTitle or seoDescription) for an element
+     * using SEOmatic's container API.
+     */
+    public static function resolveSeoValue(ElementInterface $element, string $seoKey): string
+    {
+        if (!class_exists(self::SEOMATIC_CLASS)) {
+            return '';
+        }
+
+        $uri = $element->uri;
+        if ($uri === null) {
+            return '';
+        }
+
+        /** @var \nystudio107\seomatic\Seomatic $seomatic */
+        $seomatic = \nystudio107\seomatic\Seomatic::$plugin;
+        $seomatic->metaContainers->previewMetaContainers($uri, (int)$element->siteId, true, true, $element);
+        $seomatic->metaContainers->parseGlobalVars();
+
+        $metaGlobalVars = \nystudio107\seomatic\Seomatic::$seomaticVariable?->meta;
+        if ($metaGlobalVars === null) {
+            return '';
+        }
+
+        return strip_tags($metaGlobalVars->parsedValue($seoKey) ?? '');
+    }
+
+    private function isTextField(mixed $field): bool
+    {
+        $isCkEditorField = class_exists('\craft\ckeditor\Field') && is_a($field, '\craft\ckeditor\Field');
+
+        return $field instanceof PlainText || $isCkEditorField;
+    }
+}

--- a/src/services/FieldDiscoveryService.php
+++ b/src/services/FieldDiscoveryService.php
@@ -2,7 +2,6 @@
 
 namespace samuelreichor\llmify\services;
 
-use Craft;
 use craft\base\Component;
 use craft\base\ElementInterface;
 use craft\elements\Entry;
@@ -159,11 +158,12 @@ class FieldDiscoveryService extends Component
     private function getTextFieldsFromLayout(FieldLayout $layout): array
     {
         $textFields = [];
-        foreach ($layout->getCustomFields() as $field) {
+        foreach ($layout->getCustomFieldElements() as $layoutElement) {
+            $field = $layoutElement->getField();
             if ($this->isTextField($field)) {
                 $textFields[] = [
-                    'label' => $field->name,
-                    'value' => $field->handle,
+                    'label' => $layoutElement->label(),
+                    'value' => $layoutElement->attribute(),
                 ];
             }
         }
@@ -181,23 +181,31 @@ class FieldDiscoveryService extends Component
             return [];
         }
 
-        $allFieldHandles = [];
+        $allFieldsByHandle = [];
         foreach ($entryTypes as $entryType) {
-            $textFields = array_filter($entryType->getCustomFields(), fn($field) => $this->isTextField($field));
-            $allFieldHandles[] = array_map(fn($field) => $field->handle, $textFields);
+            $fieldsInType = [];
+            foreach ($entryType->getFieldLayout()->getCustomFieldElements() as $layoutElement) {
+                $field = $layoutElement->getField();
+                if ($this->isTextField($field)) {
+                    $handle = $layoutElement->attribute();
+                    $fieldsInType[$handle] = [
+                        'label' => $layoutElement->label(),
+                        'value' => $handle,
+                    ];
+                }
+            }
+            $allFieldsByHandle[] = $fieldsInType;
         }
 
-        $commonHandles = array_intersect(...$allFieldHandles);
-        $result = [];
+        if (count($allFieldsByHandle) === 1) {
+            return array_values($allFieldsByHandle[0]);
+        }
 
-        foreach ($commonHandles as $handle) {
-            $field = Craft::$app->fields->getFieldByHandle($handle);
-            if ($field) {
-                $result[] = [
-                    'label' => $field->name,
-                    'value' => $field->handle,
-                ];
-            }
+        $commonKeys = array_keys(array_intersect_key(...$allFieldsByHandle));
+
+        $result = [];
+        foreach ($commonKeys as $handle) {
+            $result[] = $allFieldsByHandle[0][$handle];
         }
 
         return $result;
@@ -218,17 +226,23 @@ class FieldDiscoveryService extends Component
         foreach ($entryTypes as $entryType) {
             $contentBlockFieldsInType = [];
 
-            foreach ($entryType->getCustomFields() as $field) {
+            foreach ($entryType->getFieldLayout()->getCustomFieldElements() as $layoutElement) {
+                $field = $layoutElement->getField();
                 if (!$field instanceof ContentBlock) {
                     continue;
                 }
 
-                foreach ($field->getFieldLayout()->getCustomFields() as $nestedField) {
+                $cbHandle = $layoutElement->attribute();
+                $cbLabel = $layoutElement->label();
+
+                foreach ($field->getFieldLayout()->getCustomFieldElements() as $nestedLayoutElement) {
+                    $nestedField = $nestedLayoutElement->getField();
                     if ($this->isTextField($nestedField)) {
-                        $key = $field->handle . '.' . $nestedField->handle;
+                        $nestedHandle = $nestedLayoutElement->attribute();
+                        $key = $cbHandle . '.' . $nestedHandle;
                         $contentBlockFieldsInType[$key] = [
-                            'contentBlockName' => $field->name,
-                            'fieldName' => $nestedField->name,
+                            'contentBlockName' => $cbLabel,
+                            'fieldName' => $nestedLayoutElement->label(),
                         ];
                     }
                 }

--- a/src/services/FrontMatterService.php
+++ b/src/services/FrontMatterService.php
@@ -107,6 +107,12 @@ class FrontMatterService extends Component
             }
         }
 
+        // 4. Test override (bypasses all cascade levels)
+        $testData = Llmify::getTestOverrides();
+        if (!empty($testData['frontMatterFields'])) {
+            $fields = $testData['frontMatterFields'];
+        }
+
         return $fields;
     }
 

--- a/src/services/FrontMatterService.php
+++ b/src/services/FrontMatterService.php
@@ -5,9 +5,11 @@ namespace samuelreichor\llmify\services;
 use craft\base\Component;
 use craft\base\ElementInterface;
 use craft\elements\Entry;
+use craft\errors\InvalidFieldException;
 use samuelreichor\llmify\fields\LlmifySettingsField;
 use samuelreichor\llmify\Llmify;
 use samuelreichor\llmify\models\Page;
+use yii\db\Exception;
 
 class FrontMatterService extends Component
 {
@@ -69,11 +71,9 @@ class FrontMatterService extends Component
      */
     public function getAvailableBuiltInFields(): array
     {
-        $fields = [];
-        foreach ($this->builtInFields as $handle => $config) {
-            $fields[$handle] = $config['label'];
-        }
-        return $fields;
+        return array_map(function($config) {
+            return $config['label'];
+        }, $this->builtInFields);
     }
 
     /**
@@ -81,6 +81,9 @@ class FrontMatterService extends Component
      *
      * @param ElementInterface $element
      * @return array
+     * @throws InvalidFieldException
+     * @throws Exception
+     * @throws \yii\base\Exception
      */
     public function resolveFrontMatterFields(ElementInterface $element): array
     {
@@ -116,6 +119,11 @@ class FrontMatterService extends Component
         return $fields;
     }
 
+    /**
+     * @throws \yii\base\Exception
+     * @throws InvalidFieldException
+     * @throws Exception
+     */
     public function generateFrontMatter(Page $page, ?ElementInterface $element): string
     {
         // If no element, we cannot resolve fields with inheritance
@@ -154,6 +162,12 @@ class FrontMatterService extends Component
                     if ($value !== '' && $value !== null) {
                         $data[$label] = $value;
                     }
+                }
+            } elseif (str_starts_with($handle, 'seomatic:')) {
+                [, $seoKey] = explode(':', $handle, 2);
+                $value = FieldDiscoveryService::resolveSeoValue($element, $seoKey);
+                if ($value !== '') {
+                    $data[$label] = $value;
                 }
             } elseif (str_starts_with($handle, 'field:')) {
                 $fieldHandle = substr($handle, 6); // Remove 'field:' prefix

--- a/src/services/HelperService.php
+++ b/src/services/HelperService.php
@@ -7,31 +7,15 @@ use craft\base\Component;
 use craft\base\ElementInterface;
 use craft\base\FieldInterface;
 use craft\elements\Entry;
+use craft\errors\InvalidFieldException;
 use craft\errors\SiteNotFoundException;
-use craft\fields\ContentBlock;
-use craft\fields\PlainText;
 use craft\helpers\UrlHelper;
-use craft\models\EntryType;
-use craft\models\Section;
 use samuelreichor\llmify\fields\LlmifySettingsField;
 use samuelreichor\llmify\Llmify;
+use yii\base\Exception;
 
 class HelperService extends Component
 {
-    private const textFieldOptionBase = [
-        [
-            'label' => 'Custom Text',
-            'value' => 'custom',
-        ],
-        [
-            'label' => '--- Fields ---',
-            'disabled' => true,
-        ],
-        [
-            'label' => 'Title',
-            'value' => 'title',
-        ],
-    ];
     /**
      * @throws SiteNotFoundException
      */
@@ -90,181 +74,6 @@ class HelperService extends Component
         return $element::class;
     }
 
-    public function getTextFieldsForSection(Section $section): array
-    {
-        $entryTypes = $section->getEntryTypes();
-        $textFields = $this->getCommonTextFieldsForEntryTypes($entryTypes);
-        $contentBlockFields = $this->getTextFieldsInContentBlocks($entryTypes);
-
-        $result = array_merge(self::textFieldOptionBase, $textFields);
-
-        if (!empty($contentBlockFields)) {
-            $result[] = [
-                'label' => '--- Content Blocks ---',
-                'disabled' => true,
-            ];
-            $result = array_merge($result, $contentBlockFields);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Get text field options for a product type
-     *
-     * @return array<int, array{label: string, value?: string, disabled?: bool}>
-     */
-    public function getTextFieldsForProductType(object $productType): array
-    {
-        $fieldLayout = $productType->getFieldLayout();
-        if (!$fieldLayout) {
-            return self::textFieldOptionBase;
-        }
-
-        $fields = $fieldLayout->getCustomFields();
-        $textFields = [];
-
-        foreach ($fields as $field) {
-            $isCkEditorField = class_exists('\craft\ckeditor\Field') && is_a($field, '\craft\ckeditor\Field');
-            if ($field instanceof PlainText || $isCkEditorField) {
-                $textFields[] = [
-                    'label' => $field->name,
-                    'value' => $field->handle,
-                ];
-            }
-        }
-
-        return array_merge(self::textFieldOptionBase, $textFields);
-    }
-
-    public function getTextFieldsForEntry(Entry $entry): array
-    {
-        $entryTypes = [$entry->type];
-        $textFields = $this->getCommonTextFieldsForEntryTypes($entryTypes);
-        $contentBlockFields = $this->getTextFieldsInContentBlocks($entryTypes);
-
-        $result = array_merge(self::textFieldOptionBase, $textFields);
-
-        if (!empty($contentBlockFields)) {
-            $result[] = [
-                'label' => '--- Content Blocks ---',
-                'disabled' => true,
-            ];
-            $result = array_merge($result, $contentBlockFields);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Get text field options for any element
-     */
-    public function getTextFieldsForElement(ElementInterface $element): array
-    {
-        if ($element instanceof Entry) {
-            return $this->getTextFieldsForEntry($element);
-        }
-
-        if (self::isCommerceInstalled() && $element instanceof \craft\commerce\elements\Product) {
-            return $this->getTextFieldsForProductType($element->getType());
-        }
-
-        return self::textFieldOptionBase;
-    }
-
-    /**
-     * @param EntryType[] $entryTypes
-     * @return array<int, array{label: string, value: string}>
-     */
-    private function getTextFieldsInContentBlocks(array $entryTypes): array
-    {
-        if (empty($entryTypes) || !class_exists(ContentBlock::class)) {
-            return [];
-        }
-
-        $allContentBlockFields = [];
-
-        foreach ($entryTypes as $entryType) {
-            $fields = $entryType->getCustomFields();
-            $contentBlockFieldsInType = [];
-
-            foreach ($fields as $field) {
-                if (!$field instanceof ContentBlock) {
-                    continue;
-                }
-
-                $nestedFields = $field->getFieldLayout()->getCustomFields();
-                foreach ($nestedFields as $nestedField) {
-                    $isCkEditorField = class_exists('\craft\ckeditor\Field') && is_a($nestedField, '\craft\ckeditor\Field');
-                    if ($nestedField instanceof PlainText || $isCkEditorField) {
-                        $key = $field->handle . '.' . $nestedField->handle;
-                        $contentBlockFieldsInType[$key] = [
-                            'contentBlockName' => $field->name,
-                            'fieldName' => $nestedField->name,
-                        ];
-                    }
-                }
-            }
-
-            $allContentBlockFields[] = $contentBlockFieldsInType;
-        }
-
-        if (count($allContentBlockFields) === 1) {
-            $commonKeys = array_keys($allContentBlockFields[0]);
-        } else {
-            $commonKeys = array_keys(array_intersect_key(...$allContentBlockFields));
-        }
-        $result = [];
-
-        foreach ($commonKeys as $key) {
-            $info = $allContentBlockFields[0][$key];
-            $result[] = [
-                'label' => $info['contentBlockName'] . ' › ' . $info['fieldName'],
-                'value' => $key,
-            ];
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param EntryType[] $entryTypes
-     * @return array
-     */
-    private function getCommonTextFieldsForEntryTypes(array $entryTypes): array
-    {
-        if (empty($entryTypes)) {
-            return [];
-        }
-
-        $allFieldHandles = [];
-        foreach ($entryTypes as $entryType) {
-            $fields = $entryType->getCustomFields();
-            $textFields = array_filter($fields, function($field) {
-                $isCkEditorField = class_exists('\craft\ckeditor\Field') && is_a($field, '\craft\ckeditor\Field');
-                return $field instanceof PlainText || $isCkEditorField;
-            });
-            $allFieldHandles[] = array_map(function($field) {
-                return $field->handle;
-            }, $textFields);
-        }
-
-        $commonFieldHandles = array_intersect(...$allFieldHandles);
-        $commonTextFields = [];
-
-        foreach ($commonFieldHandles as $handle) {
-            $field = Craft::$app->fields->getFieldByHandle($handle);
-            if ($field) {
-                $commonTextFields[] = [
-                    'label' => $field->name,
-                    'value' => $field->handle,
-                ];
-            }
-        }
-
-        return $commonTextFields;
-    }
-
     public function getFieldOfTypeFromElement(ElementInterface $element, string $fieldClass): ?FieldInterface
     {
         $layout = $element->getFieldLayout();
@@ -290,6 +99,7 @@ class HelperService extends Component
 
     /**
      * Check if an element is excluded from LLMify via the LlmifySettingsField.
+     * @throws InvalidFieldException
      */
     public static function isElementExcluded(ElementInterface $element): bool
     {
@@ -312,6 +122,9 @@ class HelperService extends Component
         return empty($fieldData['enabled']);
     }
 
+    /**
+     * @throws Exception
+     */
     public static function getMarkdownUrl(string $uri, ?int $siteId = null): string
     {
         $mdPrefix = Llmify::getInstance()->getSettings()->markdownUrlPrefix;
@@ -320,92 +133,5 @@ class HelperService extends Component
         }
 
         return UrlHelper::siteUrl("{$uri}.md", null, null, $siteId);
-    }
-
-    /**
-     * Get combined dropdown options for front matter field selection.
-     * Returns built-in fields (with builtin: prefix) and element fields (with field: prefix).
-     *
-     * @param Section|null $section Optional section to get entry fields from
-     * @param Entry|null $entry Optional entry to get entry fields from
-     * @param object|null $productType Optional product type to get fields from
-     * @return array<int, array{label: string, value?: string, disabled?: bool}>
-     */
-    public function getFrontMatterFieldOptions(?Section $section = null, ?Entry $entry = null, ?object $productType = null): array
-    {
-        $options = [
-            ['label' => '--- Built-in Fields ---', 'disabled' => true],
-            ['label' => 'Title', 'value' => 'builtin:title'],
-            ['label' => 'Description', 'value' => 'builtin:description'],
-            ['label' => 'URL', 'value' => 'builtin:url'],
-            ['label' => 'URI', 'value' => 'builtin:uri'],
-            ['label' => 'Date Modified', 'value' => 'builtin:date_modified'],
-            ['label' => 'Date Created', 'value' => 'builtin:date_created'],
-            ['label' => 'Section', 'value' => 'builtin:section'],
-            ['label' => 'Entry Type', 'value' => 'builtin:entry_type'],
-            ['label' => 'Author', 'value' => 'builtin:author'],
-        ];
-
-        // Handle product type fields
-        if ($productType !== null) {
-            $fieldLayout = $productType->getFieldLayout();
-            if ($fieldLayout) {
-                $fields = $fieldLayout->getCustomFields();
-                $textFields = [];
-                foreach ($fields as $field) {
-                    $isCkEditorField = class_exists('\craft\ckeditor\Field') && is_a($field, '\craft\ckeditor\Field');
-                    if ($field instanceof PlainText || $isCkEditorField) {
-                        $textFields[] = $field;
-                    }
-                }
-
-                if (!empty($textFields)) {
-                    $options[] = ['label' => '--- Product Fields ---', 'disabled' => true];
-                    foreach ($textFields as $field) {
-                        $options[] = [
-                            'label' => $field->name,
-                            'value' => 'field:' . $field->handle,
-                        ];
-                    }
-                }
-            }
-
-            return $options;
-        }
-
-        // Get entry type fields (without "Custom Text" option)
-        $entryTypes = [];
-        if ($entry !== null) {
-            $entryTypes = [$entry->type];
-        } elseif ($section !== null) {
-            $entryTypes = $section->getEntryTypes();
-        }
-
-        if (!empty($entryTypes)) {
-            $textFields = $this->getCommonTextFieldsForEntryTypes($entryTypes);
-            $contentBlockFields = $this->getTextFieldsInContentBlocks($entryTypes);
-
-            if (!empty($textFields)) {
-                $options[] = ['label' => '--- Entry Fields ---', 'disabled' => true];
-                foreach ($textFields as $field) {
-                    $options[] = [
-                        'label' => $field['label'],
-                        'value' => 'field:' . $field['value'],
-                    ];
-                }
-            }
-
-            if (!empty($contentBlockFields)) {
-                $options[] = ['label' => '--- Content Blocks ---', 'disabled' => true];
-                foreach ($contentBlockFields as $field) {
-                    $options[] = [
-                        'label' => $field['label'],
-                        'value' => 'field:' . $field['value'],
-                    ];
-                }
-            }
-        }
-
-        return $options;
     }
 }

--- a/src/services/HelperService.php
+++ b/src/services/HelperService.php
@@ -13,6 +13,7 @@ use craft\fields\PlainText;
 use craft\helpers\UrlHelper;
 use craft\models\EntryType;
 use craft\models\Section;
+use samuelreichor\llmify\fields\LlmifySettingsField;
 use samuelreichor\llmify\Llmify;
 
 class HelperService extends Component
@@ -287,10 +288,38 @@ class HelperService extends Component
         return Llmify::getInstance()->getSettings()->isEnabled;
     }
 
+    /**
+     * Check if an element is excluded from LLMify via the LlmifySettingsField.
+     */
+    public static function isElementExcluded(ElementInterface $element): bool
+    {
+        $field = Llmify::getInstance()->helper->getFieldOfTypeFromElement($element, LlmifySettingsField::class);
+        if (!$field) {
+            return false;
+        }
+
+        $fieldData = $element->getFieldValue($field->handle);
+        if (!is_array($fieldData)) {
+            return false;
+        }
+
+        // Lightswitch stores '1' when on, '' when off
+        // Default to enabled (not excluded) when the key doesn't exist
+        if (!array_key_exists('enabled', $fieldData)) {
+            return false;
+        }
+
+        return empty($fieldData['enabled']);
+    }
+
     public static function getMarkdownUrl(string $uri, ?int $siteId = null): string
     {
         $mdPrefix = Llmify::getInstance()->getSettings()->markdownUrlPrefix;
-        return UrlHelper::siteUrl("{$mdPrefix}/{$uri}.md", null, null, $siteId);
+        if ($mdPrefix !== '') {
+            return UrlHelper::siteUrl("{$mdPrefix}/{$uri}.md", null, null, $siteId);
+        }
+
+        return UrlHelper::siteUrl("{$uri}.md", null, null, $siteId);
     }
 
     /**

--- a/src/services/LlmsService.php
+++ b/src/services/LlmsService.php
@@ -84,18 +84,20 @@ class LlmsService extends Component
         $siteId = Craft::$app->getSites()->getCurrentSite()->id;
         $markdownService = Llmify::getInstance()->markdown;
 
+        // Look up the element to check if it's excluded
+        $element = Entry::find()->uri($uri)->siteId($siteId)->one();
+        if (!$element && HelperService::isCommerceInstalled()) {
+            $element = \craft\commerce\elements\Product::find()->uri($uri)->siteId($siteId)->one();
+        }
+
+        if ($element && HelperService::isElementExcluded($element)) {
+            return '';
+        }
+
         $markdown = $markdownService->getRenderedMarkdown($uri, $siteId);
 
         if ($markdown !== null) {
             return $markdown;
-        }
-
-        // Try to generate on-the-fly - first try Entry
-        $element = Entry::find()->uri($uri)->siteId($siteId)->one();
-
-        // Try Commerce Product if Entry not found
-        if (!$element && HelperService::isCommerceInstalled()) {
-            $element = \craft\commerce\elements\Product::find()->uri($uri)->siteId($siteId)->one();
         }
 
         if ($element && $element->getUrl()) {
@@ -138,6 +140,10 @@ class LlmsService extends Component
             $content .= $this->constructSectionHeader($contentSetting);
 
             foreach ($elements as $element) {
+                if (HelperService::isElementExcluded($element)) {
+                    continue;
+                }
+
                 $metadata = new MetadataService($element);
                 $title = $metadata->getLlmTitle();
                 $description = $metadata->getLlmDescription();
@@ -203,10 +209,15 @@ class LlmsService extends Component
             /**
              * @var Page $page
              */
+            $element = Craft::$app->elements->getElementById($page->elementId, $page->elementType, $this->currentSiteId);
+
+            if ($element && HelperService::isElementExcluded($element)) {
+                continue;
+            }
+
             $pageContent = $page->content;
 
-            if ($settings->frontMatterInFullTxt) {
-                $element = Craft::$app->elements->getElementById($page->elementId, $page->elementType, $this->currentSiteId);
+            if ($settings->frontMatterInFullTxt && $element) {
                 $pageContent = $frontMatterService->prependFrontMatter($pageContent, $page, $element);
             }
 

--- a/src/services/LlmsService.php
+++ b/src/services/LlmsService.php
@@ -126,6 +126,15 @@ class LlmsService extends Component
         $markdownService = Llmify::getInstance()->markdown;
         $allSettings = $settingsService->getContentSettingsBySiteId($this->currentSiteId);
 
+        // Index existing pages by elementId for fast lookup
+        $groupedPages = $markdownService->getGroupedPagesForSite($this->currentSiteId);
+        $pagesByElementId = [];
+        foreach ($groupedPages as $pages) {
+            foreach ($pages as $page) {
+                $pagesByElementId[$page->elementId] = $page;
+            }
+        }
+
         foreach ($allSettings as $contentSetting) {
             if (!$markdownService->isGroupServable($contentSetting->groupId, $this->currentSiteId, $contentSetting->elementType)) {
                 continue;
@@ -144,16 +153,47 @@ class LlmsService extends Component
                     continue;
                 }
 
-                $metadata = new MetadataService($element);
-                $title = $metadata->getLlmTitle();
-                $description = $metadata->getLlmDescription();
-                $url = $shouldUseRealUrls ? $element->getUrl() : HelperService::getMarkdownUrl($element->uri);
+                // Use stored page data if available, otherwise resolve live
+                $page = $pagesByElementId[$element->id] ?? null;
+                if ($page) {
+                    $title = $page->title;
+                    $description = $page->description;
+                } else {
+                    $metadata = new MetadataService($element);
+                    $title = $metadata->getLlmTitle();
+                    $description = $metadata->getLlmDescription();
+                }
 
+                $url = $shouldUseRealUrls ? $element->getUrl() : HelperService::getMarkdownUrl($element->uri);
                 $content .= $this->constructUrl($title, $url, $description);
             }
         }
 
         return $content;
+    }
+
+    /**
+     * Find elements for a given content setting.
+     *
+     * @return array
+     */
+    private function findElementsForContentSetting(ContentSettings $contentSetting): array
+    {
+        if ($contentSetting->elementType === Entry::class) {
+            return Entry::find()
+                ->sectionId($contentSetting->groupId)
+                ->siteId($this->currentSiteId)
+                ->all();
+        }
+
+        if (HelperService::isCommerceInstalled() && $contentSetting->elementType === \craft\commerce\elements\Product::class) {
+            return \craft\commerce\elements\Product::find()
+                ->typeId($contentSetting->groupId)
+                ->siteId($this->currentSiteId)
+                ->all();
+        }
+
+        return [];
     }
 
     private function constructSectionHeader(ContentSettings $metaData): string
@@ -225,29 +265,5 @@ class LlmsService extends Component
         }
 
         return $content;
-    }
-
-    /**
-     * Find elements for a given content setting
-     *
-     * @return array
-     */
-    private function findElementsForContentSetting(ContentSettings $contentSetting): array
-    {
-        if ($contentSetting->elementType === Entry::class) {
-            return Entry::find()
-                ->sectionId($contentSetting->groupId)
-                ->siteId($this->currentSiteId)
-                ->all();
-        }
-
-        if (HelperService::isCommerceInstalled() && $contentSetting->elementType === \craft\commerce\elements\Product::class) {
-            return \craft\commerce\elements\Product::find()
-                ->typeId($contentSetting->groupId)
-                ->siteId($this->currentSiteId)
-                ->all();
-        }
-
-        return [];
     }
 }

--- a/src/services/MarkdownService.php
+++ b/src/services/MarkdownService.php
@@ -233,8 +233,17 @@ class MarkdownService extends Component
 
         $markdownRaw = $converter->convert($html);
 
-        // Remove empty links left behind after image/node removal (e.g. [](url) or [ ](url))
-        $markdownRaw = preg_replace('/\[\s*]\([^)]*\)/', '', $markdownRaw);
+        // Clean up markdown links: strip leftover HTML tags and normalize whitespace
+        $markdownRaw = preg_replace_callback('/\[((?:[^\[\]]|\[[^\]]*\])*)\]\(([^)]+)\)/', function($match) {
+            $text = trim(preg_replace('/\s+/', ' ', strip_tags($match[1])));
+            if ($text === '') {
+                return '';
+            }
+            return "[{$text}]({$match[2]})";
+        }, $markdownRaw);
+
+        // Remove empty list items left behind after node removal
+        $markdownRaw = preg_replace('/^[ \t]*-[ \t]*$/m', '', $markdownRaw);
 
         // Decode HTML entities (e.g. &amp; → &, &nbsp; → space)
         $markdownRaw = html_entity_decode($markdownRaw, ENT_QUOTES | ENT_HTML5, 'UTF-8');
@@ -250,13 +259,19 @@ class MarkdownService extends Component
      */
     private function removeTags(string $html): string
     {
+        // Fix malformed HTML where attributes are glued together without spaces
+        // (e.g. class="foo"src="bar") — PHPHtmlParser breaks on these, outputting
+        // partial attribute values as text nodes
+        $html = preg_replace('/"([a-zA-Z-]+=)/', '" $1', $html);
+
         $dom = new Dom();
         $dom->loadStr($html);
         $excludedClass = $this->getExcludeClass();
-        $nodesToRemove = $dom->find($excludedClass);
 
-        foreach ($nodesToRemove as $node) {
-            $node->delete();
+        if ($excludedClass !== '') {
+            foreach ($dom->find($excludedClass) as $node) {
+                $node->delete();
+            }
         }
 
         return $dom;

--- a/src/services/MetadataService.php
+++ b/src/services/MetadataService.php
@@ -133,6 +133,11 @@ class MetadataService extends Component
      */
     private function resolveFieldValue(string $sourceHandle): string
     {
+        if (str_starts_with($sourceHandle, 'seomatic:')) {
+            [, $seoKey] = explode(':', $sourceHandle, 2);
+            return FieldDiscoveryService::resolveSeoValue($this->element, $seoKey);
+        }
+
         if (str_contains($sourceHandle, '.')) {
             [$contentBlockHandle, $fieldHandle] = explode('.', $sourceHandle, 2);
             $contentBlock = $this->element->getFieldValue($contentBlockHandle);

--- a/src/services/PermissionService.php
+++ b/src/services/PermissionService.php
@@ -38,6 +38,19 @@ class PermissionService
     /**
      * @throws Throwable
      */
+    public static function requireViewDashboard(): bool
+    {
+        $user = Craft::$app->getUser()->getIdentity();
+        if (!$user->can(Constants::PERMISSION_VIEW_DASHBOARD)) {
+            throw new ForbiddenHttpException();
+        }
+
+        return true;
+    }
+
+    /**
+     * @throws Throwable
+     */
     public static function canGenerate(): bool
     {
         $user = Craft::$app->getUser()->getIdentity();

--- a/src/services/RefreshService.php
+++ b/src/services/RefreshService.php
@@ -203,7 +203,11 @@ class RefreshService extends Component
             $result = $contentSettings->enabled;
         }
 
-        return $result;
+        if (!$result) {
+            return false;
+        }
+
+        return !HelperService::isElementExcluded($element);
     }
 
     /**

--- a/src/services/RefreshService.php
+++ b/src/services/RefreshService.php
@@ -239,19 +239,90 @@ class RefreshService extends Component
             return '';
         }
 
-        if (!$this->isRefreshableElement($element)) {
+        // Main plugin switch — hide sidebar completely
+        if (!HelperService::isMarkdownCreationEnabled()) {
             return '';
         }
 
-        $uri = $element->uri;
-        if ($uri === null) {
+        // Structural checks — element must be entry/product, not draft, not owned, have URI
+        if (!($element instanceof Entry) && !$this->isCommerceProduct($element)) {
             return '';
         }
+
+        if (ElementHelper::isDraftOrRevision($element)) {
+            return '';
+        }
+
+        if ($element instanceof Entry && $element->getOwnerId()) {
+            return '';
+        }
+
+        if ($element->uri === null) {
+            return '';
+        }
+
+        $disabledReason = $this->getDisabledReason($element);
 
         return Html::beginTag('fieldset', ['class' => 'llmify-sidebar']) .
             Html::tag('legend', 'Llmify', ['class' => 'h6']) .
-            Html::tag('div', self::sidebarHtml($element), ['class' => 'meta']) .
+            Html::tag('div', $disabledReason !== null
+                ? self::disabledSidebarHtml($disabledReason)
+                : self::sidebarHtml($element), ['class' => 'meta']) .
             Html::endTag('fieldset');
+    }
+
+    /**
+     * Returns the reason LLMify is disabled for this element, or null if it's active.
+     *
+     * @throws \yii\base\Exception
+     */
+    private function getDisabledReason(ElementInterface $element): ?string
+    {
+        $settingsService = Llmify::getInstance()->settings;
+        $groupId = HelperService::getGroupIdForElement($element);
+
+        if ($groupId === null) {
+            return null;
+        }
+
+        $globalSettings = $settingsService->getGlobalSetting($element->siteId);
+
+        if (!$globalSettings->enabled) {
+            $currentUser = Craft::$app->getUser()->getIdentity();
+            if ($currentUser && $currentUser->can(Constants::PERMISSION_EDIT_SITE)) {
+                $site = Craft::$app->getSites()->getSiteById($element->siteId);
+                $url = UrlHelper::cpUrl('llmify/globals', $site ? ['site' => $site->handle] : []);
+                $label = Html::a('Site Settings', $url);
+            } else {
+                $label = 'Site Settings';
+            }
+            return 'LLMify disabled through ' . $label;
+        }
+
+        $elementType = HelperService::getElementTypeForElement($element);
+        $contentSettings = $settingsService->getContentSetting($groupId, $element->siteId, $elementType);
+
+        if (!$contentSettings->enabled) {
+            $currentUser = Craft::$app->getUser()->getIdentity();
+            if ($currentUser && $currentUser->can(Constants::PERMISSION_EDIT_CONTENT)) {
+                $url = UrlHelper::cpUrl('llmify/content/' . $groupId, ['elementType' => $elementType]);
+                $label = Html::a('Content Settings', $url);
+            } else {
+                $label = 'Content Settings';
+            }
+            return 'LLMify disabled through ' . $label;
+        }
+
+        if (HelperService::isElementExcluded($element)) {
+            return 'LLMify disabled through Entry Settings';
+        }
+
+        return null;
+    }
+
+    private static function disabledSidebarHtml(string $reason): string
+    {
+        return '<p style="padding-block: var(--s); margin: 0; color: var(--gray-500);">' . $reason . '</p>';
     }
 
     /**
@@ -266,6 +337,7 @@ class RefreshService extends Component
         ->select([
             'dateUpdated',
             'id',
+            'content',
         ])
         ->from([Constants::TABLE_PAGES])
         ->where(['elementId' => $element->id, 'siteId' => $element->siteId])
@@ -274,7 +346,8 @@ class RefreshService extends Component
         return Craft::$app->getView()->renderTemplate('llmify/widgets/sidebar', [
             'isRefreshable' => true,
             'page' => $page,
-            'isEnabled' => HelperService::isMarkdownCreationEnabled(),
+            'canGenerate' => PermissionService::canGenerate(),
+            'canClear' => PermissionService::canClear(),
             'markdownUrl' => HelperService::getMarkdownUrl($element->uri, $element->siteId),
             'generateActionUrl' => UrlHelper::actionUrl('llmify/markdown/generate-page?elementId=' . $element->id . '&siteId=' . $element->siteId),
             'clearActionUrl' => UrlHelper::actionUrl('llmify/markdown/clear-page?elementId=' . $element->id . '&siteId=' . $element->siteId),

--- a/src/services/SettingsService.php
+++ b/src/services/SettingsService.php
@@ -106,6 +106,13 @@ class SettingsService extends Component
             $this->saveContentSettings($settings, true, $triggerRefresh);
         }
 
+        // Apply test overrides if present
+        $testData = Llmify::getTestOverrides();
+        $csOverrides = $testData['contentSettings']["{$groupId}-{$siteId}"] ?? null;
+        if ($csOverrides !== null) {
+            $settings->setAttributes($csOverrides, false);
+        }
+
         $this->contentSettings[$cacheKey] = $settings;
         return $settings;
     }
@@ -147,6 +154,14 @@ class SettingsService extends Component
         foreach ($results as $result) {
             $result = $this->decodeContentSettingsJson($result);
             $settings = new ContentSettings($result);
+
+            // Apply test overrides if present
+            $testData = Llmify::getTestOverrides();
+            $csOverrides = $testData['contentSettings']["{$settings->groupId}-{$siteId}"] ?? null;
+            if ($csOverrides !== null) {
+                $settings->setAttributes($csOverrides, false);
+            }
+
             $this->contentSettingsBySiteId[$siteId][] = $settings;
             $cacheKey = $this->createContentCacheKey($settings->groupId, $settings->siteId, $settings->elementType);
             $this->contentSettings[$cacheKey] = $settings;
@@ -258,6 +273,13 @@ class SettingsService extends Component
             $settings = new GlobalSettings();
             $settings->siteId = $siteId;
             $this->saveGlobalSettings($settings);
+        }
+
+        // Apply test overrides if present
+        $testData = Llmify::getTestOverrides();
+        $gsOverrides = $testData['globalSettings'][(string)$siteId] ?? null;
+        if ($gsOverrides !== null) {
+            $settings->setAttributes($gsOverrides, false);
         }
 
         $this->globalSettings[$siteId] = $settings;

--- a/src/templates/fields/llmify-settings-field/input.twig
+++ b/src/templates/fields/llmify-settings-field/input.twig
@@ -115,7 +115,7 @@
       name: name ~ '[frontMatterFields]',
       id: frontMatterFieldsId,
       cols: frontMatterFieldsCols,
-      rows: value.frontMatterFields ?? defaultFrontMatterFields,
+      rows: isOverrideFrontMatterActive and value.frontMatterFields ? value.frontMatterFields : defaultFrontMatterFields,
       addRowLabel: "Add a field",
       allowAdd: true,
       allowDelete: true,

--- a/src/templates/fields/llmify-settings-field/input.twig
+++ b/src/templates/fields/llmify-settings-field/input.twig
@@ -13,6 +13,19 @@
 
 {% set frontMatterFieldsId = name ~ 'frontMatterFields' %}
 
+{% set enabledSwitchId = name ~ 'enabled' %}
+
+{# Enable/Disable Section #}
+{{ forms.lightswitchField({
+  label: 'Include in LLMify',
+  instructions: 'When disabled, this entry will be excluded from markdown generation, llms.txt, and llms-full.txt.',
+  id: enabledSwitchId,
+  name: name ~ '[enabled]',
+  on: value.enabled ?? true,
+}) }}
+
+<hr style="margin: 24px 0;">
+
 {# Title Section #}
 {{ forms.lightswitchField({
   label: 'Override Title Settings',

--- a/src/templates/fields/llmify-settings-field/input.twig
+++ b/src/templates/fields/llmify-settings-field/input.twig
@@ -15,6 +15,8 @@
 
 {% set enabledSwitchId = name ~ 'enabled' %}
 
+<div class="llmify-settings-field">
+
 {# Enable/Disable Section #}
 {{ forms.lightswitchField({
   label: 'Include in LLMify',
@@ -123,6 +125,8 @@
     }) }}
 </div>
 
+</div>
+
 {% js %}
 (function() {
     // Use vanilla JS with proper selectors
@@ -215,12 +219,19 @@
 {% endjs %}
 
 {% css %}
+    .llmify-settings-field {
+        border: 1px solid var(--gray-200);
+        border-radius: var(--large-border-radius);
+        padding: var(--xl);
+    }
+
     .fields-disabled {
         pointer-events: none;
         opacity: 0.5;
     }
 {% endcss %}
 
+{% if currentUser.can('llmify:edit-content') %}
 {% js %}
 (function() {
     // Add section settings link to the field heading
@@ -240,8 +251,13 @@
             var flexGrow = heading.querySelector(':scope > .flex-grow');
             if (flexGrow) {
                 flexGrow.before(link);
+            } else {
+                heading.style.display = 'flex';
+                heading.style.alignItems = 'center';
+                heading.appendChild(link);
             }
         }
     }
 })();
 {% endjs %}
+{% endif %}

--- a/src/templates/settings/_tabs/advanced.twig
+++ b/src/templates/settings/_tabs/advanced.twig
@@ -1,0 +1,101 @@
+{% import '_includes/forms.twig' as forms %}
+
+<h2>URL Configuration</h2>
+
+{{ forms.textField({
+  label: 'Markdown URL Prefix',
+  instructions: 'This prefix is used to generate links for the markdowns (eg. https://example.com/raw/__home__.md). Leave empty to append `.md` to the original URL (eg. https://example.com/about.md).',
+  id: 'markdownUrlPrefix',
+  name: 'markdownUrlPrefix',
+  value: settings.markdownUrlPrefix,
+  errors: settings.getErrors('markdownUrlPrefix'),
+  placeholder: 'raw',
+  first: true,
+  disabled: readOnly,
+}) }}
+
+<hr>
+
+<h2>Markdown Generation</h2>
+
+{{ forms.textField({
+  label: 'Concurrent Requests',
+  instructions: 'The max number of concurrent requests to use when generating the markdown.',
+  id: 'concurrentRequests',
+  name: 'concurrentRequests',
+  value: settings.concurrentRequests,
+  type: 'number',
+  min: 1,
+  max: 100,
+  errors: settings.getErrors('concurrentRequests'),
+  required: true,
+  unit: 'Concurrent Requests',
+  placeholder: 3,
+  disabled: readOnly,
+}) }}
+
+{{ forms.textField({
+  label: 'Request Timeout',
+  instructions: 'The max amount of seconds requests can take.',
+  id: 'requestTimeout',
+  name: 'requestTimeout',
+  value: settings.requestTimeout,
+  type: 'number',
+  min: 1,
+  errors: settings.getErrors('requestTimeout'),
+  required: true,
+  unit: 'Seconds',
+  placeholder: 100,
+  disabled: readOnly,
+}) }}
+
+<hr>
+
+<h2>Content Filtering</h2>
+
+{% set cols = {
+    classes: {
+      type: 'singleline',
+      heading: 'Classes',
+    }
+  } %}
+
+{{ forms.editableTableField({
+  label: "Exclude Classes",
+  instructions: 'CSS classes to exclude from the markdown output. Elements with these classes will be removed before conversion.',
+  name: 'excludeClasses',
+  id: 'excludeClasses',
+  cols: cols,
+  rows: settings.excludeClasses,
+  addRowLabel: "Add a class",
+  allowAdd: true,
+  allowDelete: true,
+  allowReorder: true,
+  disabled: readOnly,
+}) }}
+
+<hr>
+
+<h2>Bot Detection</h2>
+
+{% set botCols = {
+    userAgent: {
+      type: 'singleline',
+      heading: 'User Agent',
+      placeholder: 'e.g. MyCustomBot',
+    }
+  } %}
+
+{{ forms.editableTableField({
+  label: "Additional Bot User Agents",
+  instructions: 'Add custom bot identifiers to detect in addition to the built-in list: GPTBot, ClaudeBot, ChatGPT-User, Amazonbot, Bytespider, CCBot, Google-Extended, FacebookBot, PerplexityBot, Applebot-Extended, cohere-ai, OAI-SearchBot, Claude-Web.',
+  name: 'additionalBotUserAgents',
+  id: 'additionalBotUserAgents',
+  cols: botCols,
+  rows: settings.additionalBotUserAgents,
+  addRowLabel: "Add a user agent",
+  allowAdd: true,
+  allowDelete: true,
+  allowReorder: true,
+  disabled: readOnly,
+}) }}

--- a/src/templates/settings/_tabs/general.twig
+++ b/src/templates/settings/_tabs/general.twig
@@ -1,0 +1,70 @@
+{% import '_includes/forms.twig' as forms %}
+
+{{ forms.lightswitchField({
+  label: 'Enable LLMify',
+  instructions: 'Whether Markdown creation should be enabled.',
+  id: 'isEnabled',
+  name: 'isEnabled',
+  on: settings.isEnabled,
+  first: true,
+  disabled: readOnly,
+}) }}
+
+<hr>
+
+<h2>Delivery</h2>
+
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0 3rem;">
+    <div>
+        {{ forms.lightswitchField({
+          label: 'Content Negotiation',
+          instructions: 'Serve markdown when the request contains an `Accept: text/markdown` header.',
+          id: 'autoServeMarkdown',
+          name: 'autoServeMarkdown',
+          on: settings.autoServeMarkdown,
+          disabled: readOnly,
+        }) }}
+    </div>
+
+    <div>
+        {{ forms.lightswitchField({
+          label: 'AI Crawler Detection',
+          instructions: 'Serve markdown to known AI crawlers like GPTBot, ClaudeBot, and ChatGPT-User based on their user agent.',
+          id: 'enableBotDetection',
+          name: 'enableBotDetection',
+          on: settings.enableBotDetection,
+          disabled: readOnly,
+        }) }}
+    </div>
+</div>
+
+{{ forms.lightswitchField({
+  label: 'Discovery Link Tag',
+  instructions: 'Inject a `<link rel="alternate" type="text/markdown">` tag into the HTML head of pages that have markdown available.',
+  id: 'autoInjectDiscoveryTag',
+  name: 'autoInjectDiscoveryTag',
+  on: settings.autoInjectDiscoveryTag,
+  disabled: readOnly,
+}) }}
+
+<hr>
+
+<h2>Output</h2>
+
+{{ forms.lightswitchField({
+  label: 'Use Real URLs in llms.txt',
+  instructions: 'Whether real page URLs or the markdown URLs should be used in the llms.txt file.',
+  id: 'isRealUrlLlm',
+  name: 'isRealUrlLlm',
+  on: settings.isRealUrlLlm,
+  disabled: readOnly,
+}) }}
+
+{{ forms.lightswitchField({
+  label: 'Include Front Matter in llms-full.txt',
+  instructions: 'Whether front matter should also be included for each page in llms-full.txt. Front matter fields are configured per site in the Site Settings.',
+  id: 'frontMatterInFullTxt',
+  name: 'frontMatterInFullTxt',
+  on: settings.frontMatterInFullTxt,
+  disabled: readOnly,
+}) }}

--- a/src/templates/settings/content/edit.twig
+++ b/src/templates/settings/content/edit.twig
@@ -47,7 +47,12 @@
     {{ hiddenInput('siteId', siteId) }}
     {{ hiddenInput('elementType', elementType) }}
 
-    <h2 style="margin-top:0">Section Settings</h2>
+    <div style="display: flex; align-items: center; justify-content: space-between; margin-top: 0; margin-bottom: 24px;">
+        <h2 style="margin: 0;">Section Settings</h2>
+        {% if currentUser.can('llmify:edit-site') %}
+            <a href="{{ cpUrl('llmify/globals', { site: selectedSite.handle }) }}" class="go" style="font-size: 13px;">Site Settings</a>
+        {% endif %}
+    </div>
     {{ forms.lightswitchField({
         label: 'Enable for Section',
         instructions: 'Activates or deactivates LLM processing for all elements within this group for the current site. If turned off, no content from this group will be processed.',

--- a/src/templates/settings/content/edit.twig
+++ b/src/templates/settings/content/edit.twig
@@ -140,7 +140,7 @@
         }
       } %}
 
-    {% set displayedFrontMatterFields = settings.frontMatterFields|length ? settings.frontMatterFields : inheritedFrontMatterFields %}
+    {% set displayedFrontMatterFields = (settings.overrideFrontMatter ?? false) and settings.frontMatterFields|length ? settings.frontMatterFields : inheritedFrontMatterFields %}
 
     <div id="frontMatterFieldsWrapper" class="{% if not (settings.overrideFrontMatter ?? false) %}fields-disabled{% endif %}">
         {{ forms.editableTableField({

--- a/src/templates/settings/content/edit.twig
+++ b/src/templates/settings/content/edit.twig
@@ -5,10 +5,6 @@
 {% set selectedSubnavItem = 'content' %}
 {% set fullPageForm = true %}
 
-{% set crumbs = [
-    { label: "LLMify Content"|t('app'), url: url('llmify/content') }
-] %}
-
 {% if selectableSites is not defined %}
     {% if siteIds is defined %}
         {% set selectableSites = craft.app.sites.getEditableSites()|filter(s => s.id in siteIds) %}
@@ -27,16 +23,20 @@
     {% endif %}
 {% endif %}
 
-{% set crumbs = (crumbs ?? [])|unshift({
-    id: 'site-crumb',
-    icon: 'world',
-    iconAltText: 'Site'|t('app'),
-    label: selectedSite.name|t('site'),
-    menu: {
-        items: siteMenuItems(selectableSites, selectedSite),
-        label: 'Select site'|t('app')
-    }
-}) %}
+{% set crumbs = [
+    {
+        id: 'site-crumb',
+        icon: 'world',
+        iconAltText: 'Site'|t('app'),
+        label: selectedSite.name|t('site'),
+        menu: {
+            items: siteMenuItems(selectableSites, selectedSite),
+            label: 'Select site'|t('app')
+        }
+    },
+    { label: 'LLMify', url: cpUrl('llmify') },
+    { label: 'Content', url: cpUrl('llmify/content') },
+] %}
 
 {% block content %}
     {{ actionInput('llmify/content/save-section-settings') }}

--- a/src/templates/settings/content/index.twig
+++ b/src/templates/settings/content/index.twig
@@ -22,16 +22,19 @@
     {% endif %}
 {% endif %}
 
-{% set crumbs = (crumbs ?? [])|unshift({
-    id: 'site-crumb',
-    icon: 'world',
-    iconAltText: 'Site'|t('app'),
-    label: selectedSite.name|t('site'),
-    menu: {
-        items: siteMenuItems(selectableSites, selectedSite),
-        label: 'Select site'|t('app')
-    }
-}) %}
+{% set crumbs = [
+    {
+        id: 'site-crumb',
+        icon: 'world',
+        iconAltText: 'Site'|t('app'),
+        label: selectedSite.name|t('site'),
+        menu: {
+            items: siteMenuItems(selectableSites, selectedSite),
+            label: 'Select site'|t('app')
+        }
+    },
+    { label: 'LLMify', url: cpUrl('llmify') },
+] %}
 
 {% block content %}
     <div id="content-vue-admin-table"></div>

--- a/src/templates/settings/dashboard/_circle.twig
+++ b/src/templates/settings/dashboard/_circle.twig
@@ -1,0 +1,27 @@
+{#
+  Circular progress indicator.
+  Pass `percent` (0–100).
+#}
+{% set percent = percent|default(0)|round %}
+{% set radius = 20 %}
+{% set circumference = 2 * 3.14159 * radius %}
+{% set offset = circumference - (percent / 100) * circumference %}
+
+{% if percent >= 80 %}
+    {% set colorClass = 'green' %}
+{% elseif percent >= 50 %}
+    {% set colorClass = 'orange' %}
+{% else %}
+    {% set colorClass = 'red' %}
+{% endif %}
+
+<div class="llmify-circle-progress">
+    <svg viewBox="0 0 48 48">
+        <circle class="llmify-circle-bg" cx="24" cy="24" r="{{ radius }}"/>
+        <circle class="llmify-circle-fill {{ colorClass }}"
+                cx="24" cy="24" r="{{ radius }}"
+                stroke-dasharray="{{ circumference }}"
+                stroke-dashoffset="{{ offset }}"/>
+    </svg>
+    <span class="llmify-circle-label">{{ percent }}%</span>
+</div>

--- a/src/templates/settings/dashboard/index.twig
+++ b/src/templates/settings/dashboard/index.twig
@@ -1,0 +1,614 @@
+{% extends "_layouts/cp" %}
+
+{% set title = "Dashboard" %}
+{% set selectedSubnavItem = 'dashboard' %}
+
+{# Site Selector Crumb #}
+{% if selectableSites is not defined %}
+    {% if siteIds is defined %}
+        {% set selectableSites = craft.app.sites.getEditableSites()|filter(s => s.id in siteIds) %}
+    {% else %}
+        {% set selectableSites = craft.app.sites.getEditableSites() %}
+    {% endif %}
+{% endif %}
+
+{% if selectedSite is not defined %}
+    {% if selectedSiteId is defined %}
+        {% set selectedSite = craft.app.sites.getSiteById(selectedSiteId) %}
+    {% elseif requestedSite and requestedSite in selectableSites %}
+        {% set selectedSite = requestedSite %}
+    {% else %}
+        {% set selectedSite = selectableSites|length ? selectableSites|first : craft.app.sites.getPrimarySite() %}
+    {% endif %}
+{% endif %}
+
+{% set crumbs = [
+    {
+        id: 'site-crumb',
+        icon: 'world',
+        iconAltText: 'Site'|t('app'),
+        label: selectedSite.name|t('site'),
+        menu: {
+            items: siteMenuItems(selectableSites, selectedSite),
+            label: 'Select site'|t('app')
+        }
+    },
+    { label: 'LLMify', url: cpUrl('llmify') },
+] %}
+
+{% block content %}
+    {# Plugin Settings Quick Bar #}
+    <div class="llmify-quickbar">
+        <div class="llmify-quickbar-items">
+            <span class="llmify-quickbar-item">
+                <span class="llmify-check {{ pluginChecks.isEnabled ? 'on' : 'off' }}"></span>
+                Plugin {{ pluginChecks.isEnabled ? 'Active' : 'Inactive' }}
+            </span>
+            <span class="llmify-quickbar-sep"></span>
+            <span class="llmify-quickbar-item">
+                <span class="llmify-check {{ pluginChecks.autoServe ? 'on' : 'off' }}"></span>
+                Auto-Serve
+            </span>
+            <span class="llmify-quickbar-sep"></span>
+            <span class="llmify-quickbar-item">
+                <span class="llmify-check {{ pluginChecks.botDetection ? 'on' : 'off' }}"></span>
+                Bot Detection
+            </span>
+            <span class="llmify-quickbar-sep"></span>
+            <span class="llmify-quickbar-item">
+                <span class="llmify-check {{ pluginChecks.discoveryTag ? 'on' : 'off' }}"></span>
+                Discovery Tag
+            </span>
+            {% if currentUser.admin and craft.app.config.general.allowAdminChanges %}
+                <a href="{{ cpUrl('llmify/settings') }}" class="llmify-quickbar-link">Configure</a>
+            {% endif %}
+        </div>
+    </div>
+
+    {# Top Row: Site Setup + Generation side by side #}
+    <div class="llmify-top-row">
+        {# Site Setup #}
+        <div class="llmify-panel">
+            <div class="llmify-panel-header">
+                <div>
+                    <h2>Site Setup
+                        {% if currentUser.can('llmify:edit-site') and craft.app.config.general.allowAdminChanges %}
+                            <a href="{{ cpUrl('llmify/globals', { site: selectedSite.handle }) }}" class="btn small">Configure</a>
+                        {% endif %}
+                    </h2>
+                    <p class="light">Global settings for this site</p>
+                </div>
+                {% include "llmify/settings/dashboard/_circle" with { percent: siteSetup.score } %}
+            </div>
+            <div class="llmify-card">
+                <div class="llmify-card-body">
+                    <ul class="llmify-checklist">
+                        {% for check in siteSetup.checks %}
+                            <li>
+                                <span class="llmify-check {{ check.ok ? 'on' : 'off' }}"></span>
+                                <span>{{ check.label }}</span>
+                                {% if check.detail %}
+                                    <span class="llmify-value">{{ check.detail }}</span>
+                                {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        {# Generation Stats #}
+        <div class="llmify-panel">
+            <div class="llmify-panel-header">
+                <div>
+                    <h2>Generation
+                        {% if currentUser.can('llmify:generate') or currentUser.can('llmify:clear') %}
+                            <a href="{{ cpUrl('utilities/llmify') }}" class="btn small">Utilities</a>
+                        {% endif %}
+                    </h2>
+                    <p class="light">Markdown coverage & health</p>
+                </div>
+                {% include "llmify/settings/dashboard/_circle" with { percent: generationStats.coveragePercent } %}
+            </div>
+            <div class="llmify-card">
+                <div class="llmify-card-body">
+                    <div class="llmify-stat-block">
+                        <div class="llmify-stat-label">Markdown Coverage</div>
+                        <div class="llmify-progress-bar">
+                            {% if generationStats.coveragePercent >= 80 %}
+                                {% set barClass = 'green' %}
+                            {% elseif generationStats.coveragePercent >= 50 %}
+                                {% set barClass = 'orange' %}
+                            {% else %}
+                                {% set barClass = 'red' %}
+                            {% endif %}
+                            <div class="llmify-progress-fill {{ barClass }}" style="width: {{ generationStats.coveragePercent }}%"></div>
+                        </div>
+                        <div class="llmify-stat-detail">
+                            <strong>{{ generationStats.totalPages }}/{{ generationStats.totalElements }}</strong> Entries
+                        </div>
+                    </div>
+
+                    <div class="llmify-stats-grid">
+                        <div class="llmify-stat-block">
+                            <div class="llmify-stat-label">Last Refresh</div>
+                            <div class="llmify-stat-value">
+                                {% if generationStats.lastRefresh %}
+                                    {{ generationStats.lastRefresh|date('M j, Y H:i') }}
+                                {% else %}
+                                    <span class="light">Never</span>
+                                {% endif %}
+                            </div>
+                        </div>
+
+                        <div class="llmify-stat-block">
+                            <div class="llmify-stat-label">Oldest Page</div>
+                            <div class="llmify-stat-value">
+                                {% if generationStats.oldestPage %}
+                                    {{ generationStats.oldestPage|date('M j, Y') }}
+                                    {% set daysSinceOldest = ((now.timestamp - generationStats.oldestPage|date('U')) / 86400)|round %}
+                                    {% if daysSinceOldest > 90 %}
+                                        <span class="llmify-warning">{{ daysSinceOldest }}d old</span>
+                                    {% endif %}
+                                {% else %}
+                                    <span class="light">N/A</span>
+                                {% endif %}
+                            </div>
+                        </div>
+
+                        <div class="llmify-stat-block">
+                            <div class="llmify-stat-label">Avg. Tokens per Page</div>
+                            <div class="llmify-stat-value">
+                                ~{{ generationStats.avgTokens|number_format(0) }}
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {# Full-width: Content Setup #}
+    <div class="llmify-panel">
+        <div class="llmify-panel-header">
+            <div>
+                <h2>Content Setup</h2>
+                <p class="light">Per-section configuration</p>
+            </div>
+            {% include "llmify/settings/dashboard/_circle" with { percent: contentSetup.score } %}
+        </div>
+        <div class="llmify-card">
+            <div class="llmify-card-body">
+                {% if contentSetup.sections|length == 0 %}
+                    <p class="light">No sections configured.</p>
+                {% else %}
+                    <div class="llmify-content-table-wrap">
+                        <table class="llmify-content-table">
+                            <thead>
+                                <tr>
+                                    <th>Section</th>
+                                    <th class="llmify-center">Active</th>
+                                    <th class="llmify-center">Title</th>
+                                    <th class="llmify-center">Description</th>
+                                    <th class="llmify-center">Section Title</th>
+                                    <th class="llmify-center">Section Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for section in contentSetup.sections %}
+                                    {% set checks = section.checks %}
+                                    <tr class="{{ not checks.enabled ? 'llmify-disabled-row' : '' }}">
+                                        <td>
+                                            <a href="{{ section.editUrl }}">{{ section.groupName }}</a>
+                                            <span class="llmify-type-badge">{{ section.groupType }}</span>
+                                            {% if checks.enabled %}
+                                                <span class="llmify-count-badge">{{ section.elementCount }}</span>
+                                            {% endif %}
+                                        </td>
+                                        <td class="llmify-center">
+                                            <span class="llmify-check {{ checks.enabled ? 'on' : 'off' }}"></span>
+                                        </td>
+                                        <td class="llmify-center">
+                                            {% if checks.enabled %}
+                                                <span class="llmify-check {{ checks.hasTitle ? 'on' : 'off' }}"></span>
+                                            {% else %}
+                                                <span class="llmify-check neutral"></span>
+                                            {% endif %}
+                                        </td>
+                                        <td class="llmify-center">
+                                            {% if checks.enabled %}
+                                                <span class="llmify-check {{ checks.hasDescription ? 'on' : 'off' }}"></span>
+                                            {% else %}
+                                                <span class="llmify-check neutral"></span>
+                                            {% endif %}
+                                        </td>
+                                        <td class="llmify-center">
+                                            {% if checks.enabled %}
+                                                <span class="llmify-check {{ checks.hasSectionTitle ? 'on' : 'off' }}"></span>
+                                            {% else %}
+                                                <span class="llmify-check neutral"></span>
+                                            {% endif %}
+                                        </td>
+                                        <td class="llmify-center">
+                                            {% if checks.enabled %}
+                                                <span class="llmify-check {{ checks.hasSectionDescription ? 'on' : 'off' }}"></span>
+                                            {% else %}
+                                                <span class="llmify-check neutral"></span>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% css %}
+    /* Quickbar */
+    .llmify-quickbar {
+        background: var(--gray-050);
+        border: 1px solid var(--hairline-color);
+        border-radius: var(--large-border-radius);
+        padding: 10px 16px;
+        margin-bottom: 24px;
+    }
+
+    .llmify-quickbar-items {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+        font-size: 13px;
+    }
+
+    .llmify-quickbar-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .llmify-quickbar-item code {
+        font-size: 12px;
+        padding: 1px 5px;
+        background: var(--gray-100);
+        border-radius: var(--small-border-radius);
+    }
+
+    .llmify-quickbar-sep {
+        width: 1px;
+        height: 16px;
+        background: var(--hairline-color);
+    }
+
+    .llmify-quickbar-link {
+        margin-left: auto;
+        font-size: 12px;
+    }
+
+    /* Top row: two panels side by side, equal height */
+    .llmify-top-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+        margin-bottom: 24px;
+        align-items: stretch;
+    }
+
+    .llmify-top-row > .llmify-panel {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .llmify-top-row > .llmify-panel > .llmify-card {
+        flex: 1;
+    }
+
+    @media (max-width: 900px) {
+        .llmify-top-row {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    /* Panel = header + card */
+    .llmify-panel {
+        min-width: 0;
+    }
+
+    .llmify-panel-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 12px;
+    }
+
+    .llmify-panel-header h2 {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-color);
+    }
+
+    .llmify-panel-header p {
+        margin: 2px 0 0;
+        font-size: 12px;
+    }
+
+    /* Circular progress */
+    .llmify-circle-progress {
+        position: relative;
+        width: 52px;
+        height: 52px;
+        flex-shrink: 0;
+    }
+
+    .llmify-circle-progress svg {
+        transform: rotate(-90deg);
+        width: 52px;
+        height: 52px;
+    }
+
+    .llmify-circle-bg {
+        fill: none;
+        stroke: var(--gray-200);
+        stroke-width: 4;
+    }
+
+    .llmify-circle-fill {
+        fill: none;
+        stroke-width: 4;
+        stroke-linecap: round;
+        transition: stroke-dashoffset 0.6s ease;
+    }
+
+    .llmify-circle-fill.green { stroke: #22C55E; }
+    .llmify-circle-fill.orange { stroke: #F59E0B; }
+    .llmify-circle-fill.red { stroke: #EF4444; }
+
+    .llmify-circle-label {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 12px;
+        font-weight: 700;
+        color: var(--text-color);
+    }
+
+    /* Cards */
+    .llmify-card {
+        background: var(--white);
+        border: 1px solid var(--hairline-color);
+        border-radius: var(--large-border-radius);
+    }
+
+    .llmify-card-body {
+        padding: 14px 18px;
+    }
+
+    .llmify-card-footer {
+        padding: 10px 18px;
+        border-top: 1px solid var(--hairline-color);
+    }
+
+    /* Checklist */
+    .llmify-checklist {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .llmify-checklist li {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 0;
+        font-size: 13px;
+        border-bottom: 1px solid var(--gray-050);
+    }
+
+    .llmify-checklist li:last-child {
+        border-bottom: none;
+    }
+
+    .llmify-value {
+        color: var(--medium-text-color);
+        font-size: 12px;
+        margin-left: auto;
+        max-width: 200px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    /* Check icons */
+    .llmify-check {
+        flex-shrink: 0;
+    }
+
+    .llmify-check.on::before {
+        content: '\2713';
+        color: #22C55E;
+        font-weight: 700;
+        font-size: 15px;
+    }
+
+    .llmify-check.off::before {
+        content: '\2717';
+        color: #EF4444;
+        font-weight: 700;
+        font-size: 15px;
+    }
+
+    .llmify-check.neutral::before {
+        content: '\2014';
+        color: var(--gray-300);
+        font-size: 14px;
+    }
+
+    /* Content table */
+    .llmify-content-table-wrap {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .llmify-content-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+        min-width: 500px;
+    }
+
+    .llmify-content-table th {
+        font-weight: 600;
+        font-size: 12px;
+        color: var(--medium-text-color);
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+        padding: 8px 10px;
+        border-bottom: 2px solid var(--hairline-color);
+        text-align: left;
+    }
+
+    .llmify-content-table td {
+        padding: 10px;
+        border-bottom: 1px solid var(--hairline-color);
+    }
+
+    .llmify-content-table tr:last-child td {
+        border-bottom: none;
+    }
+
+    .llmify-center {
+        text-align: center !important;
+    }
+
+    .llmify-disabled-row {
+        opacity: 0.45;
+    }
+
+    .llmify-type-badge {
+        font-size: 11px;
+        color: var(--medium-text-color);
+        background: var(--gray-050);
+        padding: 2px 6px;
+        border-radius: var(--small-border-radius);
+        margin-left: 4px;
+    }
+
+    .llmify-count-badge {
+        font-size: 11px;
+        color: var(--medium-text-color);
+        margin-left: 2px;
+    }
+
+    .llmify-count-badge::before { content: '('; }
+    .llmify-count-badge::after { content: ')'; }
+
+    /* Stats */
+    .llmify-stat-block {
+        margin-bottom: 14px;
+    }
+
+    .llmify-stat-block:last-child {
+        margin-bottom: 0;
+    }
+
+    .llmify-stat-label {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--medium-text-color);
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+        margin-bottom: 4px;
+    }
+
+    .llmify-stat-value {
+        font-size: 14px;
+    }
+
+    .llmify-stat-detail {
+        font-size: 13px;
+        margin-top: 4px;
+    }
+
+    /* Stats 2-col grid within generation card */
+    .llmify-stats-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+        margin-top: 14px;
+        padding-top: 14px;
+        border-top: 1px solid var(--hairline-color);
+    }
+
+    .llmify-stats-grid .llmify-stat-block {
+        margin-bottom: 0;
+    }
+
+    /* Progress bar */
+    .llmify-progress-bar {
+        height: 8px;
+        background: var(--gray-100);
+        border-radius: 4px;
+        overflow: hidden;
+        margin: 6px 0;
+    }
+
+    .llmify-progress-fill {
+        height: 100%;
+        border-radius: 4px;
+        transition: width 0.3s ease;
+    }
+
+    .llmify-progress-fill.green { background: #22C55E; }
+    .llmify-progress-fill.orange { background: #F59E0B; }
+    .llmify-progress-fill.red { background: #EF4444; }
+
+    /* Warning badge */
+    .llmify-warning {
+        color: #D97706;
+        font-size: 12px;
+        font-weight: 600;
+    }
+
+    /* Mobile */
+    @media (max-width: 600px) {
+        .llmify-quickbar {
+            padding: 8px 12px;
+        }
+
+        .llmify-quickbar-sep {
+            display: none;
+        }
+
+        .llmify-quickbar-items {
+            gap: 4px 12px;
+        }
+
+        .llmify-panel-header {
+            gap: 8px;
+        }
+
+        .llmify-panel-header h2 .btn {
+            display: none;
+        }
+
+        .llmify-stats-grid {
+            grid-template-columns: 1fr;
+        }
+
+        .llmify-card-body {
+            padding: 10px 12px;
+        }
+
+        .llmify-value {
+            max-width: 100px;
+        }
+    }
+{% endcss %}

--- a/src/templates/settings/globals/index.twig
+++ b/src/templates/settings/globals/index.twig
@@ -23,16 +23,19 @@
     {% endif %}
 {% endif %}
 
-{% set crumbs = (crumbs ?? [])|unshift({
-    id: 'site-crumb',
-    icon: 'world',
-    iconAltText: 'Site'|t('app'),
-    label: selectedSite.name|t('site'),
-    menu: {
-        items: siteMenuItems(selectableSites, selectedSite),
-        label: 'Select site'|t('app')
-    }
-}) %}
+{% set crumbs = [
+    {
+        id: 'site-crumb',
+        icon: 'world',
+        iconAltText: 'Site'|t('app'),
+        label: selectedSite.name|t('site'),
+        menu: {
+            items: siteMenuItems(selectableSites, selectedSite),
+            label: 'Select site'|t('app')
+        }
+    },
+    { label: 'LLMify', url: cpUrl('llmify') },
+] %}
 
 {% block content %}
     {{ actionInput('llmify/globals/save-settings') }}

--- a/src/templates/settings/index.twig
+++ b/src/templates/settings/index.twig
@@ -4,6 +4,10 @@
 {% set fullPageForm = true %}
 {% set selectedSubnavItem = 'settings' %}
 
+{% set crumbs = [
+    { label: 'LLMify', url: cpUrl('llmify') },
+] %}
+
 {% set tabs = {
     general: { label: 'General', url: '#general' },
     advanced: { label: 'Advanced', url: '#advanced' },

--- a/src/templates/settings/index.twig
+++ b/src/templates/settings/index.twig
@@ -1,0 +1,29 @@
+{% extends '_layouts/cp' %}
+
+{% set title = 'LLMify Settings' %}
+{% set fullPageForm = true %}
+{% set selectedSubnavItem = 'settings' %}
+
+{% set tabs = {
+    general: { label: 'General', url: '#general' },
+    advanced: { label: 'Advanced', url: '#advanced' },
+} %}
+
+{% block content %}
+
+    <input type="hidden" name="action" value="llmify/settings/save-settings">
+    {{ redirectInput('llmify/settings') }}
+
+    <div id="general">
+        {% namespace 'settings' %}
+            {% include 'llmify/settings/_tabs/general' %}
+        {% endnamespace %}
+    </div>
+
+    <div id="advanced" class="hidden">
+        {% namespace 'settings' %}
+            {% include 'llmify/settings/_tabs/advanced' %}
+        {% endnamespace %}
+    </div>
+
+{% endblock %}

--- a/src/templates/widgets/sidebar.twig
+++ b/src/templates/widgets/sidebar.twig
@@ -1,10 +1,10 @@
 {% import '_includes/forms' as forms %}
 
 {% set markdownExists = page != null %}
+{% set markdownEmpty = markdownExists and (page.content is empty) %}
 <div class="data">
   <div class="heading">Status</div>
   <div class="value statusMsg" style="justify-content: space-between">
-    {% if isEnabled %}
     <p>
       {% if markdownExists %}
         <a href="{{ markdownUrl }}" target="_blank" rel="noopener">Generated</a>
@@ -12,32 +12,41 @@
         Not generated
       {% endif %}
     </p>
-    {% else %}
-      <p>Plugin disabled</p>
-    {% endif %}
   </div>
+  {% if markdownEmpty %}
+    <div class="heading"></div>
+    <div class="value">
+      <p class="warning with-icon" style="margin: 0;">
+        Markdown empty. Check your <a href="https://samuelreichor.at/libraries/craft-llmify/usage/content-control" target="_blank" rel="noopener">template setup</a> for more information.
+      </p>
+    </div>
+  {% endif %}
   {% if markdownExists %}
     <div class="heading status-update">Last Updated</div>
     <div class="value status-update">{{ page.dateUpdated|datetime('short') }}</div>
   {% endif %}
-  {% if isEnabled %}
-    <div class="llmify-btn-group">
-      {{ tag('button', {
-        text: 'Update',
-        class: 'btn primary generate',
-        data: {
-          action: generateActionUrl,
-        },
-      }) }}
+  {% if canGenerate or canClear %}
+  <div class="llmify-btn-group">
+    {% if canGenerate %}
+    {{ tag('button', {
+      text: 'Update',
+      class: 'btn primary generate',
+      data: {
+        action: generateActionUrl,
+      },
+    }) }}
+    {% endif %}
 
-      {{ tag('button', {
-        text: 'Clear',
-        class: 'btn secondary clear',
-        data: {
-          action: clearActionUrl,
-        },
-      }) }}
-    </div>
+    {% if canClear %}
+    {{ tag('button', {
+      text: 'Clear',
+      class: 'btn secondary clear',
+      data: {
+        action: clearActionUrl,
+      },
+    }) }}
+    {% endif %}
+  </div>
   {% endif %}
 </div>
 
@@ -91,17 +100,21 @@
           }
         })
   }
-  generateBtn.addEventListener('click', (e) => {
-    e.preventDefault()
-    const actionUrl = generateBtn.dataset.action;
-    sendActionRequest(actionUrl, 'Updated')
-  })
+  if (generateBtn) {
+    generateBtn.addEventListener('click', (e) => {
+      e.preventDefault()
+      const actionUrl = generateBtn.dataset.action;
+      sendActionRequest(actionUrl, 'Updated')
+    })
+  }
 
-  clearBtn.addEventListener('click', (e) => {
-    e.preventDefault()
-    const actionUrl = clearBtn.dataset.action;
-    sendActionRequest(actionUrl, 'Cleared')
-  })
+  if (clearBtn) {
+    clearBtn.addEventListener('click', (e) => {
+      e.preventDefault()
+      const actionUrl = clearBtn.dataset.action;
+      sendActionRequest(actionUrl, 'Cleared')
+    })
+  }
 </script>
 
 


### PR DESCRIPTION
## 1.4.0 - 2026-04-11

### Added
- Add dashboard with site setup scores and section-level content statistics.
- Add AI crawler detection to auto-serve markdown to known bots (GPTBot, ClaudeBot, ChatGPT-User, and more) based on user agent.
- Add `<link rel="alternate" type="text/markdown">` discovery tag injection with configurable toggle.
- Add `/.well-known/llms.txt` route for RFC 8615 compliant discovery.
- Add per-entry exclude toggle via the LlmifySettingsField to individually exclude entries from markdown generation and all LLM outputs. #13 
- Add SEOmatic field support for automatic front matter population.
- Add `Vary: Accept` header to all markdown endpoints and `Vary: Accept, User-Agent` to auto-serve responses.
- Add `X-Robots-Tag: noindex, nofollow` header to auto-serve responses.
- Add custom bot user agent configuration for extending the built-in bot list.
- Add markdown preview targets for entries and products.
- Add direct links to content and site settings from the entry sidebar and settings field.

### Improved
- Reorganize plugin settings into a tabbed UI (General, Advanced) integrated into the plugin subnav.
- Enable content negotiation (`autoServeMarkdown`) and AI crawler detection (`enableBotDetection`) by default for fresh installs.
- Make `markdownUrlPrefix` optional, leave it empty to use `${url}.md` URLs directly.
- Refactor field discovery into dedicated `FieldDiscoveryService`.
- Improve sidebar panel UX: show informative messages when LLMify is disabled at the site, section, or entry level instead of hiding the panel. Respect generate and clear permissions for sidebar buttons.
- Enhance markdown generation for images inside links.

### Fixed
- Fix breadcrumbs in all plugin pages.
- Fix bug in field discovery service with field layout overwrites.
- Fix UI issue with front matter inheritance in the settings field.
- Fix issue with cached SEOmatic field values in llms.txt.