### PR TITLE
Release 1.9.0

### DIFF
--- a/.claude/skills/install-llmify/SKILL.md
+++ b/.claude/skills/install-llmify/SKILL.md
@@ -47,9 +47,9 @@ To exclude specific parts within an llmify block:
 ```twig
 {% llmify %}
   <h1>{{ entry.title }}</h1>
-  {% excludellmify %}
+  {% excludeLlmify %}
     <nav>...</nav>
-  {% endexcludellmify %}
+  {% endexcludeLlmify %}
   <div>{{ entry.bodyContent }}</div>
 {% endllmify %}
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release Notes for LLMify
 
+## 1.9.0 - 2026-07-18
+
+### Added
+- Add WebMCP support: the new `enableWebMcp` setting exposes your enabled content to in-browser AI agents (e.g. Gemini in Chrome) via the experimental [WebMCP](https://github.com/webmachinelearning/webmcp) standard. A script served at `/webmcp.js` registers read-only `search_content`, `get_page`, `list_sections`, and `navigate_to` tools backed by the same content gating as the public markdown routes.
+- Add `WebMcpService::EVENT_REGISTER_TOOLS` so modules and plugins can register custom WebMCP tools or modify and remove the built-in ones.
+- Add `mdUrl()`, `chatGptUrl()`, and `claudeUrl()` Twig functions that return the markdown URL of an element and prompt links for opening it in ChatGPT or Claude.
+
+### Changed
+- `enableBotDetection` now defaults to `false` for new installs. Serving markdown based on the user agent is an explicit opt-in.
+
 ## 1.8.0 - 2026-06-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,96 +1,61 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
 
-## Project Overview
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
-LLMify is a Craft CMS 5 plugin (PHP 8.2+) that transforms site content into AI-ready formats. It generates clean markdown versions of Twig templates, produces `llms.txt` and `llms-full.txt` files for LLM consumption, detects AI bots, and can auto-serve markdown content. Supports both Craft Entries and Commerce Products.
+## 1. Think Before Coding
 
-Namespace: `samuelreichor\llmify`
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
 
-## Development Commands
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
 
-```bash
-# Code style (ECS with Craft CMS rules via ecs.php)
-composer check-cs      # Check code style
-composer fix-cs        # Fix code style issues
+## 2. Simplicity First
 
-# Static analysis
-composer phpstan       # Run PHPStan (level 4)
+**Minimum code that solves the problem. Nothing speculative.**
 
-# Console commands (run from Craft project root)
-php craft llmify/markdown/generate  # Generate markdown for all enabled entries
-php craft llmify/markdown/clear     # Clear all generated markdown
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
 ```
 
-CI runs PHPStan + ECS on every pull request to `main` (`.github/workflows/ci.yml`). No test suite in this repo — testing is handled externally.
-
-## Architecture
-
-### Plugin Entry Point
-`src/Llmify.php` (~700 lines) - Registers services, Twig extensions, event listeners, URL rules, permissions, and sidebar panels. Services are defined in `config()` and accessed as plugin components (e.g., `Llmify::getInstance()->markdown`).
-
-### Services (`src/services/`)
-Core services:
-- **MarkdownService** - Converts HTML to markdown using `league/html-to-markdown`, stores results in `llmify_pages` table
-- **RefreshService** - Handles markdown regeneration triggered by element changes, uses queue jobs (`src/jobs/RefreshMarkdownJob.php`)
-- **SettingsService** - Manages per-section and per-site configuration stored in `llmify_globals` table
-- **RequestService** - Makes async HTTP requests using `amphp/http-client` to fetch rendered pages for markdown conversion
-
-Supporting services:
-- **BotDetectionService** - Detects AI crawlers (GPTBot, ClaudeBot, ChatGPT-User, etc.) via user-agent
-- **DashboardService** - Calculates site setup scores and section statistics for the CP dashboard
-- **FieldDiscoveryService** - Discovers relevant fields (including SEOmatic) for markdown generation
-- **FrontMatterService** - Generates YAML front matter from SEOmatic fields and metadata
-- **HelperService** - Utility functions (markdown URL generation, feature availability checks)
-- **LlmsService** - Generates `llms.txt` and `llms-full.txt` content
-- **MetadataService** - Manages element metadata storage and retrieval
-- **PermissionService** - Permission management (Pro Edition only)
-
-### Key Components
-- **Twig Extension** (`src/twig/`) - Custom tags `{% llmify %}...{% endllmify %}` and `{% excludellmify %}...{% endexcludellmify %}` control what HTML is included/excluded in markdown output
-- **LlmifySettingsField** (`src/fields/`) - Custom Craft field for per-entry markdown control
-- **LlmifyChangedBehavior** (`src/behaviors/`) - Attached to elements to track changes and trigger refresh
-- **SiteUrlBatcher** (`src/batchers/`) - Collects URLs in batches for async processing
-- **Constants** (`src/Constants.php`) - Database table names, permission constants, and `X-Llmify-Refresh-Request` header
-
-### Models & Records
-- **Models** (`src/models/`) - Data objects: `Page`, `ContentSettings`, `GlobalSettings`, `PluginSettings`
-- **Records** (`src/records/`) - ActiveRecord classes for `llmify_pages`, `llmify_metadata`, `llmify_globals`
-
-### Event-Driven Architecture
-The plugin listens to Craft element events (save, delete, restore, move) to automatically queue markdown regeneration. Element changes are tracked via `LlmifyChangedBehavior`. Auto-serve mode intercepts template rendering to return markdown instead of HTML when an `Accept: text/markdown` header is present or an AI bot is detected.
-
-### URL Routes
-Site routes:
-- `/llms.txt` and `/.well-known/llms.txt` - Summary text file
-- `/llms-full.txt` - Full content file
-- `/{prefix}/<slug>.md` - Individual markdown pages (prefix configurable, default: `raw`)
-
-CP routes under `llmify/`: dashboard, content (per-section settings), globals (per-site settings), settings (plugin config).
-
-### Commerce Support
-Soft dependency on Craft Commerce — supports Product elements alongside Entries. Commerce-related PHPStan errors are ignored in `phpstan.neon`.
-
-## Key Dependencies
-- `amphp/http-client` - Async HTTP requests for batch processing
-- `league/html-to-markdown` - HTML to markdown conversion
-- `paquettg/php-html-parser` - DOM manipulation for excluding content by CSS class
-
-## Database Tables
-Defined in `src/Constants.php` and created by `src/migrations/Install.php`:
-- `llmify_pages` - Stores generated markdown content per element/site (supports entries and products via `elementType` column)
-- `llmify_globals` - Site-level settings
-- `llmify_metadata` - Content metadata per group/element type
-
-## Plugin Settings
-Configurable via `config/llmify.php` (see `src/models/PluginSettings.php` for all options):
-- `isEnabled` - Master toggle
-- `markdownUrlPrefix` - URL prefix for markdown files (default: `raw`)
-- `excludeClasses` - CSS classes to exclude from output
-- `markdownConfig` - Options passed to HTML-to-markdown converter
-- `enableAutoServe` - Serve markdown on `Accept: text/markdown` header
-- `enableBotDetection` - Auto-detect AI crawlers and serve markdown
-- `enableDiscoveryTag` - Inject `<link rel="alternate" type="text/markdown">` tags
-- `enableSeomatic` - Pull front matter from SEOmatic fields
-- `concurrentRequests` / `requestTimeout` - Async request tuning
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Combined with Craft Commerce compatibility, granular control over your Markdowns
 ### Content Generation
 - **Pre-Generated Markdown**: Async batch processing with [amphp](https://amphp.org/) stores Markdown in a dedicated database table for instant delivery at any scale.
 - **On-Demand Fallback**: Automatically generates Markdown on first request if not yet pre-generated.
-- **Template-Level Control**: Use `{% llmify %}` and `{% excludellmify %}` Twig tags for precise control over what content is included in your Markdown output.
+- **Template-Level Control**: Use `{% llmify %}` and `{% excludeLlmify %}` Twig tags for precise control over what content is included in your Markdown output.
 - **CSS Class Exclusion**: Define classes to exclude entire sections from the HTML-to-Markdown conversion.
 - **YAML Front Matter**: Configurable metadata with hierarchical inheritance (Site > Section > Entry).
 - **Console Commands**: `llmify/markdown/generate` and `llmify/markdown/clear` for CI/CD and deployment workflows.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Optimize your site for LLMs",
   "type": "craft-plugin",
   "license": "proprietary",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "support": {
     "email": "samuelreichor@gmail.com",
     "issues": "https://github.com/samuelreichor/craft-llmify/issues?state=open",

--- a/src/Llmify.php
+++ b/src/Llmify.php
@@ -46,6 +46,7 @@ use samuelreichor\llmify\services\MetadataService;
 use samuelreichor\llmify\services\RefreshService;
 use samuelreichor\llmify\services\RequestService;
 use samuelreichor\llmify\services\SettingsService;
+use samuelreichor\llmify\services\WebMcpService;
 use samuelreichor\llmify\twig\LlmifyExtension;
 use samuelreichor\llmify\utilities\Utils;
 use Throwable;
@@ -71,6 +72,7 @@ use yii\log\FileTarget;
  * @property-read FrontMatterService $frontMatter
  * @property-read BotDetectionService $botDetection
  * @property-read DashboardService $dashboard
+ * @property-read WebMcpService $webMcp
  */
 class Llmify extends Plugin
 {
@@ -103,6 +105,7 @@ class Llmify extends Plugin
                 'frontMatter' => FrontMatterService::class,
                 'botDetection' => BotDetectionService::class,
                 'dashboard' => DashboardService::class,
+                'webMcp' => WebMcpService::class,
             ],
         ];
     }
@@ -130,6 +133,7 @@ class Llmify extends Plugin
                 if (!$isHeadless) {
                     $this->registerAutoServeEvent();
                     $this->registerDiscoveryLinkTag();
+                    $this->registerWebMcpScriptTag();
                 }
             }
 
@@ -612,6 +616,42 @@ class Llmify extends Plugin
                 $mdPrefix = $this->getSettings()->markdownUrlPrefix;
                 $mdRoute = $mdPrefix !== '' ? $mdPrefix . '/<slug:.*\.md>' : '<slug:.*\.md>';
                 $event->rules[$mdRoute] = 'llmify/file/generate-page-md';
+
+                if ($this->getSettings()->enableWebMcp) {
+                    $event->rules['webmcp.js'] = 'llmify/web-mcp/script';
+                }
+            }
+        );
+    }
+
+    /**
+     * Injects the WebMCP script onto rendered front-end pages so the in-browser
+     * agent can discover and call the tools. Registered once per request and
+     * only when WebMCP is enabled.
+     */
+    private function registerWebMcpScriptTag(): void
+    {
+        if (!$this->getSettings()->enableWebMcp) {
+            return;
+        }
+
+        $registered = false;
+
+        Event::on(
+            View::class,
+            View::EVENT_BEFORE_RENDER_TEMPLATE,
+            function(TemplateEvent $event) use (&$registered) {
+                if ($registered || $event->templateMode !== 'site') {
+                    return;
+                }
+
+                $registered = true;
+
+                Craft::$app->view->registerJsFile(
+                    UrlHelper::siteUrl('webmcp.js'),
+                    ['type' => 'module'],
+                    'llmify-webmcp',
+                );
             }
         );
     }

--- a/src/controllers/WebMcpController.php
+++ b/src/controllers/WebMcpController.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace samuelreichor\llmify\controllers;
+
+use Craft;
+use craft\errors\SiteNotFoundException;
+use craft\web\Controller;
+use samuelreichor\llmify\Llmify;
+use samuelreichor\llmify\services\HelperService;
+use samuelreichor\llmify\services\WebMcpService;
+use yii\web\BadRequestHttpException;
+use yii\web\NotFoundHttpException;
+use yii\web\Response;
+
+/**
+ * WebMCP Controller
+ *
+ * Public, read-only endpoints that back the browser WebMCP tools:
+ *
+ *  - `actionScript()`   serves `/webmcp.js`, the script that registers the tools.
+ *  - `actionSearch()`   the `search_content` tool backend.
+ *  - `actionPage()`     the `get_page` tool backend.
+ *  - `actionSections()` the `list_sections` tool backend.
+ *
+ * The endpoints are unauthenticated by design (the agent runs in the visitor's
+ * browser), so they only ever expose content that is already public via the
+ * markdown routes. All actions are GET/idempotent, the search query is length-
+ * and limit-capped and cached, and the whole controller 404s unless the plugin
+ * is enabled and WebMCP support is turned on in the plugin settings.
+ *
+ * @author Samuel Reichör <samuelreichor@gmail.com>
+ */
+class WebMcpController extends Controller
+{
+    protected array|bool|int $allowAnonymous = true;
+
+    /**
+     * @inheritdoc
+     */
+    public $enableCsrfValidation = false;
+
+    /**
+     * @inheritdoc
+     *
+     * @throws NotFoundHttpException
+     */
+    public function beforeAction($action): bool
+    {
+        if (!parent::beforeAction($action)) {
+            return false;
+        }
+
+        // Craft routes `actions/llmify/web-mcp/<action>` straight to this
+        // controller regardless of the site URL rules, so the master toggle has
+        // to be re-checked here — the URL-rule guard in Llmify::init() only
+        // covers the pretty `/webmcp.js` route.
+        if (!HelperService::isMarkdownCreationEnabled() || !Llmify::getInstance()->getSettings()->enableWebMcp) {
+            throw new NotFoundHttpException('WebMCP support is not enabled.');
+        }
+
+        Craft::$app->getResponse()->getHeaders()->set('X-Robots-Tag', 'noindex, nofollow');
+
+        return true;
+    }
+
+    /**
+     * Serves the client-side script that registers the WebMCP tools.
+     */
+    public function actionScript(): Response
+    {
+        $script = Llmify::getInstance()->webMcp->getScript();
+
+        $headers = Craft::$app->getResponse()->getHeaders();
+        $headers->set('Content-Type', 'text/javascript; charset=UTF-8');
+        // The tool set changes with settings/content, so always revalidate
+        // rather than letting the browser serve a stale registration script.
+        $headers->set('Cache-Control', 'no-cache');
+
+        return $this->asRaw($script);
+    }
+
+    /**
+     * Backend for the `search_content` tool. Enforces a minimum query length and
+     * caps the result count; responses are briefly cached to blunt abuse of the
+     * unauthenticated endpoint.
+     *
+     * @throws BadRequestHttpException
+     * @throws SiteNotFoundException
+     */
+    public function actionSearch(): Response
+    {
+        $query = trim((string)$this->request->getRequiredParam('q'));
+        $queryLength = mb_strlen($query);
+
+        if ($queryLength < WebMcpService::MIN_QUERY_LENGTH) {
+            throw new BadRequestHttpException('The search query must be at least ' . WebMcpService::MIN_QUERY_LENGTH . ' characters long.');
+        }
+
+        // Cap the length so the unauthenticated endpoint can't be driven with
+        // huge unique queries that each miss the cache and hit the search index.
+        if ($queryLength > WebMcpService::MAX_QUERY_LENGTH) {
+            throw new BadRequestHttpException('The search query must be at most ' . WebMcpService::MAX_QUERY_LENGTH . ' characters long.');
+        }
+
+        // Clamp before building the cache key so out-of-range limits can't
+        // flood the cache with duplicate entries.
+        $limit = (int)$this->request->getParam('limit', WebMcpService::DEFAULT_SEARCH_LIMIT);
+        $limit = max(1, min($limit, WebMcpService::MAX_SEARCH_LIMIT));
+        $siteId = Craft::$app->getSites()->getCurrentSite()->id;
+
+        $cacheKey = ['llmify-webmcp-search', $siteId, mb_strtolower($query), $limit];
+        $results = Craft::$app->getCache()->getOrSet($cacheKey, function() use ($query, $siteId, $limit) {
+            return Llmify::getInstance()->webMcp->search($query, $siteId, $limit);
+        }, 60);
+
+        return $this->asJson(['results' => $results]);
+    }
+
+    /**
+     * Backend for the `get_page` tool. Delegates to `LlmsService` so the same
+     * exclusion gating as the public `.md` routes applies. On-demand generation
+     * is disabled here and the lookup is cached, so this unauthenticated
+     * endpoint can only ever serve already-generated markdown and can't be used
+     * to trigger blocking server-side renders.
+     *
+     * @throws BadRequestHttpException
+     * @throws NotFoundHttpException
+     * @throws SiteNotFoundException
+     */
+    public function actionPage(): Response
+    {
+        $uri = (string)$this->request->getRequiredParam('uri');
+        $siteId = Craft::$app->getSites()->getCurrentSite()->id;
+
+        $cacheKey = ['llmify-webmcp-page', $siteId, $uri];
+        $markdown = Craft::$app->getCache()->getOrSet($cacheKey, function() use ($uri) {
+            return Llmify::getInstance()->llms->getMarkdownForUri($uri, allowOnDemand: false);
+        }, 60);
+
+        if ($markdown === '') {
+            throw new NotFoundHttpException('No content found for URI: ' . $uri);
+        }
+
+        return $this->asJson(['uri' => $uri, 'markdown' => $markdown]);
+    }
+
+    /**
+     * Backend for the `list_sections` tool.
+     *
+     * @throws SiteNotFoundException
+     */
+    public function actionSections(): Response
+    {
+        $siteId = Craft::$app->getSites()->getCurrentSite()->id;
+        $sections = Llmify::getInstance()->webMcp->getSections($siteId);
+
+        return $this->asJson(['sections' => $sections]);
+    }
+}

--- a/src/events/RegisterWebMcpToolsEvent.php
+++ b/src/events/RegisterWebMcpToolsEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace samuelreichor\llmify\events;
+
+use yii\base\Event;
+
+/**
+ * Fired when the WebMCP tool set is built, before the registration script is
+ * generated. Listeners can append custom tools, tweak the native definitions,
+ * or remove tools entirely. A tool appended with the name of an existing tool
+ * replaces it.
+ *
+ * Each tool is an array with:
+ *
+ *  - `name`         The unique tool name, e.g. `book_appointment`.
+ *  - `description`  What the tool does, shown to the browser agent.
+ *  - `inputSchema`  JSON Schema describing the tool input.
+ *  - `handler`      Client-side JS function source executed when the agent
+ *                   calls the tool: `async (input, helpers) => result`.
+ *                   `helpers` provides `text(value)` to build a text result,
+ *                   `fetchTool(url)` for same-origin JSON fetches, and
+ *                   `config`. Native tools have built-in handlers and don't
+ *                   need this key.
+ *
+ * ```php
+ * use samuelreichor\llmify\events\RegisterWebMcpToolsEvent;
+ * use samuelreichor\llmify\services\WebMcpService;
+ * use yii\base\Event;
+ *
+ * Event::on(WebMcpService::class, WebMcpService::EVENT_REGISTER_TOOLS,
+ *     function(RegisterWebMcpToolsEvent $event) {
+ *         $event->tools[] = [
+ *             'name' => 'get_opening_hours',
+ *             'description' => 'Get the opening hours of the store.',
+ *             'inputSchema' => ['type' => 'object'],
+ *             'handler' => <<<JS
+ * async (input, helpers) => {
+ *   const r = await helpers.fetchTool(new URL('/api/opening-hours', location.origin));
+ *   return helpers.text(r.ok ? JSON.stringify(r.data) : 'Opening hours are unavailable.');
+ * }
+ * JS,
+ *         ];
+ *     }
+ * );
+ * ```
+ *
+ * @author Samuel Reichör <samuelreichor@gmail.com>
+ */
+class RegisterWebMcpToolsEvent extends Event
+{
+    /**
+     * @var array<int, array{name?: string, description?: string, inputSchema?: array<string, mixed>, handler?: string}>
+     */
+    public array $tools = [];
+}

--- a/src/models/PluginSettings.php
+++ b/src/models/PluginSettings.php
@@ -26,7 +26,7 @@ class PluginSettings extends Model
     ];
     public bool $autoInjectDiscoveryTag = true;
     public bool $enableWebMcp = false;
-    public bool $enableBotDetection = true;
+    public bool $enableBotDetection = false;
     public array $additionalBotUserAgents = [];
     public bool $frontMatterInFullTxt = false;
 

--- a/src/models/PluginSettings.php
+++ b/src/models/PluginSettings.php
@@ -25,6 +25,7 @@ class PluginSettings extends Model
         ],
     ];
     public bool $autoInjectDiscoveryTag = true;
+    public bool $enableWebMcp = false;
     public bool $enableBotDetection = true;
     public array $additionalBotUserAgents = [];
     public bool $frontMatterInFullTxt = false;

--- a/src/services/LlmsService.php
+++ b/src/services/LlmsService.php
@@ -78,9 +78,14 @@ class LlmsService extends Component
     }
 
     /**
+     * Returns the stored markdown for a URI, or an empty string when none is
+     * available. When `$allowOnDemand` is false, a cache miss returns an empty
+     * string instead of triggering a blocking on-the-fly render — used by
+     * unauthenticated callers that must not be able to drive server-side work.
+     *
      * @throws SiteNotFoundException
      */
-    public function getMarkdownForUri(string $uri): string
+    public function getMarkdownForUri(string $uri, bool $allowOnDemand = true): string
     {
         $siteId = Craft::$app->getSites()->getCurrentSite()->id;
         $markdownService = Llmify::getInstance()->markdown;
@@ -99,6 +104,10 @@ class LlmsService extends Component
 
         if ($markdown !== null) {
             return $markdown;
+        }
+
+        if (!$allowOnDemand) {
+            return '';
         }
 
         // Headless mode never generates on-the-fly via a Twig render; it relies

--- a/src/services/RefreshService.php
+++ b/src/services/RefreshService.php
@@ -187,10 +187,15 @@ class RefreshService extends Component
     }
 
     /**
+     * Whether the element is currently servable as markdown (group enabled and
+     * the element not excluded). Pass `$triggerRefresh = false` from read-only
+     * callers (e.g. Twig functions on a front-end render) so the gating check
+     * can't enqueue a refresh as a side effect of backfilling missing settings.
+     *
      * @throws Exception
      * @throws \yii\base\Exception
      */
-    public function canRefreshElement(ElementInterface $element): bool
+    public function canRefreshElement(ElementInterface $element, bool $triggerRefresh = true): bool
     {
         $settingsService = Llmify::getInstance()->settings;
         $groupId = HelperService::getGroupIdForElement($element);
@@ -204,7 +209,7 @@ class RefreshService extends Component
 
         $result = false;
         if ($globalSettings->enabled) {
-            $contentSettings = $settingsService->getContentSetting($groupId, $element->siteId, $elementType);
+            $contentSettings = $settingsService->getContentSetting($groupId, $element->siteId, $elementType, $triggerRefresh);
             $result = $contentSettings->enabled;
         }
 

--- a/src/services/WebMcpService.php
+++ b/src/services/WebMcpService.php
@@ -1,0 +1,441 @@
+<?php
+
+namespace samuelreichor\llmify\services;
+
+use Craft;
+use craft\base\Component;
+use craft\base\ElementInterface;
+use craft\elements\Entry;
+use craft\errors\InvalidFieldException;
+use craft\helpers\Json;
+use craft\helpers\UrlHelper;
+use samuelreichor\llmify\events\RegisterWebMcpToolsEvent;
+use samuelreichor\llmify\Llmify;
+use yii\base\Exception;
+
+/**
+ * WebMCP Service
+ *
+ * Backs the browser WebMCP (`document.modelContext`) integration: it builds the
+ * client-side script that registers the tools and resolves the read-only data
+ * those tools request. All content access reuses the same gating as the public
+ * markdown routes — only LLMify-enabled, non-excluded content is ever exposed.
+ *
+ * Modules and plugins can extend the tool set via `EVENT_REGISTER_TOOLS`.
+ *
+ * @author Samuel Reichör <samuelreichor@gmail.com>
+ */
+class WebMcpService extends Component
+{
+    /**
+     * Fired when the WebMCP tool set is built. Listeners can add custom tools
+     * (with a client-side JS `handler`), modify the native definitions, or
+     * remove tools entirely. See {@see RegisterWebMcpToolsEvent}.
+     *
+     * @event RegisterWebMcpToolsEvent
+     */
+    public const EVENT_REGISTER_TOOLS = 'registerTools';
+
+    public const MAX_SEARCH_LIMIT = 25;
+    public const DEFAULT_SEARCH_LIMIT = 10;
+    public const MIN_QUERY_LENGTH = 2;
+    public const MAX_QUERY_LENGTH = 200;
+
+    /**
+     * Builds the JavaScript that registers the WebMCP tools with the browser
+     * agent. Tool descriptors come from `getTools()`; the `execute` handlers
+     * for the native tools live in the script, custom tools bring their own
+     * handler source. All data values are JSON-encoded to avoid script
+     * injection; custom handler source is emitted as-is and is trusted the
+     * same way any registered event handler is.
+     */
+    public function getScript(): string
+    {
+        $config = Json::encode([
+            'searchUrl' => UrlHelper::actionUrl('llmify/web-mcp/search'),
+            'pageUrl' => UrlHelper::actionUrl('llmify/web-mcp/page'),
+            'sectionsUrl' => UrlHelper::actionUrl('llmify/web-mcp/sections'),
+            'defaultLimit' => self::DEFAULT_SEARCH_LIMIT,
+        ]);
+
+        $definitions = [];
+        $handlerEntries = [];
+
+        foreach ($this->getTools() as $tool) {
+            $definitions[] = [
+                'name' => $tool['name'],
+                'description' => $tool['description'] ?? '',
+                'inputSchema' => $tool['inputSchema'] ?? ['type' => 'object'],
+            ];
+
+            if (isset($tool['handler'])) {
+                $handlerEntries[] = Json::encode($tool['name']) . ': (' . $tool['handler'] . ')';
+            }
+        }
+
+        $tools = Json::encode($definitions);
+        $customHandlers = implode(",\n    ", $handlerEntries);
+
+        return <<<JS
+(() => {
+  // Chrome 149 exposes the API on navigator.modelContext; Chrome 150+ moved it
+  // to document.modelContext (navigator alias deprecated). Support both.
+  const ctx = document.modelContext || navigator.modelContext;
+  if (!ctx || typeof ctx.registerTool !== 'function') {
+    return;
+  }
+
+  const CFG = {$config};
+  const TOOLS = {$tools};
+
+  const text = (value) => ({ content: [{ type: 'text', text: value }] });
+
+  // Escape markdown link metacharacters so content-derived titles/descriptions
+  // can't forge links or inject extra list entries in the result the agent reads.
+  const mdEscape = (value) => String(value ?? '').replace(/[\\[\\]()\\\\]/g, '\\\\$&').replace(/[\\r\\n]+/g, ' ');
+
+  // Never throw out of a tool: the agent handles a text result far better than
+  // a failed invocation. Non-OK responses come back as { ok: false }.
+  const fetchTool = async (url) => {
+    try {
+      const res = await fetch(url, {
+        headers: { Accept: 'application/json' },
+        credentials: 'same-origin',
+      });
+      if (!res.ok) {
+        return { ok: false, status: res.status };
+      }
+      return { ok: true, data: await res.json() };
+    } catch (e) {
+      return { ok: false, status: 0 };
+    }
+  };
+
+  // Passed to custom tool handlers so they get the same utilities as the
+  // native tools.
+  const helpers = { text, fetchTool, config: CFG };
+
+  // Handlers contributed via the EVENT_REGISTER_TOOLS PHP event. A custom
+  // handler with a native tool's name takes precedence, so tools can be
+  // overridden.
+  const customHandlers = {
+    {$customHandlers}
+  };
+
+  const handlers = {
+    search_content: async ({ query, limit }) => {
+      const url = new URL(CFG.searchUrl, location.origin);
+      url.searchParams.set('q', query);
+      url.searchParams.set('limit', String(limit ?? CFG.defaultLimit));
+      const r = await fetchTool(url);
+      if (!r.ok) {
+        return text('Search is currently unavailable on this site.');
+      }
+      if (!r.data.results || r.data.results.length === 0) {
+        return text('No matching content found for "' + query + '".');
+      }
+      const lines = r.data.results.map(
+        (item) => '- [' + mdEscape(item.title) + '](' + item.url + ')' + (item.description ? ': ' + mdEscape(item.description) : '')
+      );
+      return text(lines.join('\\n'));
+    },
+    get_page: async ({ uri }) => {
+      const url = new URL(CFG.pageUrl, location.origin);
+      url.searchParams.set('uri', uri);
+      const r = await fetchTool(url);
+      if (!r.ok) {
+        return text('No page is available for URI "' + uri + '".');
+      }
+      return text(r.data.markdown || '');
+    },
+    list_sections: async () => {
+      const r = await fetchTool(new URL(CFG.sectionsUrl, location.origin));
+      if (!r.ok || !r.data.sections || r.data.sections.length === 0) {
+        return text('No searchable sections are available.');
+      }
+      return text(r.data.sections.map((s) => '- ' + s.name).join('\\n'));
+    },
+    navigate_to: async ({ uri }) => {
+      let target;
+      try {
+        target = new URL(uri, location.origin);
+      } catch (e) {
+        return text('Invalid URI: ' + uri);
+      }
+      if (target.origin !== location.origin) {
+        return text('Refused to navigate to a different origin.');
+      }
+      // Defer the navigation so the tool result is delivered before the page
+      // unloads; assigning synchronously tears down the call and the agent
+      // sees a failed invocation instead of a result.
+      setTimeout(() => location.assign(target.href), 50);
+      return text('Navigating to ' + target.pathname);
+    },
+  };
+
+  for (const tool of TOOLS) {
+    const custom = customHandlers[tool.name];
+    const execute = custom ? (input) => custom(input, helpers) : handlers[tool.name];
+    if (!execute) {
+      continue;
+    }
+    ctx.registerTool({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      execute,
+    });
+  }
+})();
+JS;
+    }
+
+    /**
+     * The final WebMCP tool set: the native definitions, extended/modified by
+     * `EVENT_REGISTER_TOOLS` listeners. Tools without a name are dropped, and
+     * when several tools share a name the last one wins, so appended tools can
+     * override native ones.
+     *
+     * @return array<int, array{name: string, description?: string, inputSchema?: array<string, mixed>, handler?: string}>
+     */
+    public function getTools(): array
+    {
+        $tools = $this->getToolDefinitions();
+
+        if ($this->hasEventHandlers(self::EVENT_REGISTER_TOOLS)) {
+            $event = new RegisterWebMcpToolsEvent(['tools' => $tools]);
+            $this->trigger(self::EVENT_REGISTER_TOOLS, $event);
+            $tools = $event->tools;
+        }
+
+        $toolsByName = [];
+        foreach ($tools as $tool) {
+            $name = $tool['name'] ?? null;
+            if (!is_string($name) || $name === '') {
+                continue;
+            }
+            $toolsByName[$name] = $tool;
+        }
+
+        return array_values($toolsByName);
+    }
+
+    /**
+     * The native WebMCP tool descriptors (name, description, JSON Schema
+     * input); only read-only tools are exposed, plus a client-side navigation
+     * tool. Use `getTools()` for the final, event-extended tool set.
+     *
+     * @return array<int, array{name: string, description: string, inputSchema: array<string, mixed>}>
+     */
+    public function getToolDefinitions(): array
+    {
+        return [
+            [
+                'name' => 'search_content',
+                'description' => 'Search this website\'s content. Returns a list of matching pages with their title, description and URL.',
+                'inputSchema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'query' => [
+                            'type' => 'string',
+                            'description' => 'The search keywords.',
+                        ],
+                        'limit' => [
+                            'type' => 'integer',
+                            'description' => 'Maximum number of results to return (1-' . self::MAX_SEARCH_LIMIT . ').',
+                            'default' => self::DEFAULT_SEARCH_LIMIT,
+                            'minimum' => 1,
+                            'maximum' => self::MAX_SEARCH_LIMIT,
+                        ],
+                    ],
+                    'required' => ['query'],
+                ],
+            ],
+            [
+                'name' => 'get_page',
+                'description' => 'Fetch the full Markdown content of a single page on this website, identified by its URI (path).',
+                'inputSchema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'uri' => [
+                            'type' => 'string',
+                            'description' => 'The page URI/path, e.g. "news/my-article".',
+                        ],
+                    ],
+                    'required' => ['uri'],
+                ],
+            ],
+            [
+                'name' => 'list_sections',
+                'description' => 'List the content sections of this website that can be searched.',
+                'inputSchema' => [
+                    'type' => 'object',
+                ],
+            ],
+            [
+                'name' => 'navigate_to',
+                'description' => 'Navigate the browser to a page on this website, identified by its URI (path).',
+                'inputSchema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'uri' => [
+                            'type' => 'string',
+                            'description' => 'The page URI/path to navigate to, e.g. "about".',
+                        ],
+                    ],
+                    'required' => ['uri'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Full-text searches the LLMify-enabled content of a site and returns a
+     * capped list of matches. Disabled sections, excluded elements and pages
+     * without a URI are skipped, so the result is always a subset of the
+     * already-public markdown pages.
+     *
+     * @return array<int, array{title: string, description: string, uri: string, url: string}>
+     * @throws InvalidFieldException
+     * @throws Exception
+     */
+    public function search(string $query, int $siteId, int $limit = self::DEFAULT_SEARCH_LIMIT): array
+    {
+        $limit = max(1, min($limit, self::MAX_SEARCH_LIMIT));
+
+        $entrySectionIds = [];
+        $productTypeIds = [];
+
+        $commerceInstalled = HelperService::isCommerceInstalled();
+
+        foreach ($this->_getServableContentSettings($siteId) as $contentSetting) {
+            if ($contentSetting->elementType === Entry::class) {
+                $entrySectionIds[] = $contentSetting->groupId;
+            } elseif ($commerceInstalled && $contentSetting->elementType === \craft\commerce\elements\Product::class) {
+                $productTypeIds[] = $contentSetting->groupId;
+            }
+        }
+
+        // Fetch a headroom of candidates per type so that post-query filtering
+        // (excluded elements, missing URIs) can't shrink the result below the
+        // requested limit while servable matches still exist deeper down.
+        $fetch = min($limit * 2, self::MAX_SEARCH_LIMIT);
+
+        /** @var ElementInterface[] $elements */
+        $elements = [];
+
+        if (!empty($entrySectionIds)) {
+            $elements = Entry::find()
+                ->sectionId($entrySectionIds)
+                ->siteId($siteId)
+                ->search($query)
+                ->orderBy('score')
+                ->limit($fetch)
+                ->all();
+        }
+
+        if (!empty($productTypeIds)) {
+            $products = \craft\commerce\elements\Product::find()
+                ->typeId($productTypeIds)
+                ->siteId($siteId)
+                ->search($query)
+                ->orderBy('score')
+                ->limit($fetch)
+                ->all();
+            $elements = array_merge($elements, $products);
+        }
+
+        // Entries and products come back as two separately ranked lists; sort
+        // the merged set by search score so the best matches win across types.
+        usort($elements, static fn(ElementInterface $a, ElementInterface $b) => ($b->searchScore ?? 0) <=> ($a->searchScore ?? 0));
+
+        $results = [];
+
+        foreach ($elements as $element) {
+            if ($element->uri === null) {
+                continue;
+            }
+
+            if (HelperService::isElementExcluded($element)) {
+                continue;
+            }
+
+            $metadata = new MetadataService($element);
+            $results[] = [
+                'title' => $metadata->getLlmTitle(),
+                'description' => $metadata->getLlmDescription(),
+                'uri' => $element->uri,
+                'url' => HelperService::getMarkdownUrl($element->uri, $siteId),
+            ];
+
+            if (count($results) >= $limit) {
+                break;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Returns the LLMify-enabled, servable content sections for a site, used by
+     * the `list_sections` tool.
+     *
+     * @return array<int, array{name: string, type: string}>
+     */
+    public function getSections(int $siteId): array
+    {
+        $sections = [];
+
+        foreach ($this->_getServableContentSettings($siteId) as $contentSetting) {
+            $name = $this->_resolveGroupName($contentSetting->groupId, $contentSetting->elementType);
+            if ($name === null) {
+                continue;
+            }
+
+            $sections[] = [
+                'name' => $name,
+                'type' => $contentSetting->elementType === Entry::class ? 'entries' : 'products',
+            ];
+        }
+
+        return $sections;
+    }
+
+    /**
+     * Returns the content settings for a site whose group is LLMify-enabled and
+     * currently servable. Shared by `search()` and `getSections()` so both tools
+     * gate on exactly the same content.
+     *
+     * @return array<int, \samuelreichor\llmify\models\ContentSettings>
+     */
+    private function _getServableContentSettings(int $siteId): array
+    {
+        $markdownService = Llmify::getInstance()->markdown;
+        $contentSettings = Llmify::getInstance()->settings->getContentSettingsBySiteId($siteId);
+
+        return array_values(array_filter(
+            $contentSettings,
+            static fn($contentSetting) => $markdownService->isGroupServable(
+                $contentSetting->groupId,
+                $siteId,
+                $contentSetting->elementType,
+            ),
+        ));
+    }
+
+    /**
+     * Resolves the display name of a section or product type.
+     */
+    private function _resolveGroupName(int $groupId, string $elementType): ?string
+    {
+        if ($elementType === Entry::class) {
+            return Craft::$app->entries->getSectionById($groupId)?->name;
+        }
+
+        if (HelperService::isCommerceInstalled() && $elementType === \craft\commerce\elements\Product::class) {
+            return \craft\commerce\Plugin::getInstance()->getProductTypes()->getProductTypeById($groupId)?->name;
+        }
+
+        return null;
+    }
+}

--- a/src/templates/settings/_tabs/general.twig
+++ b/src/templates/settings/_tabs/general.twig
@@ -49,6 +49,20 @@
 
 <hr>
 
+<h2>AI Agents</h2>
+
+{{ forms.lightswitchField({
+  label: 'WebMCP',
+  instructions: 'Expose your content to in-browser AI agents (e.g. Gemini in Chrome) via the experimental [WebMCP](https://github.com/webmachinelearning/webmcp) standard. Injects a small script that registers read-only tools (search content, fetch a page, list sections, navigate) backed by your enabled content.',
+  warning: 'WebMCP is an experimental, pre-standard browser API (Chrome only). Enabling this publishes a public, machine-callable search/content API over your already-public content.',
+  id: 'enableWebMcp',
+  name: 'enableWebMcp',
+  on: settings.enableWebMcp,
+  disabled: readOnly,
+}) }}
+
+<hr>
+
 <h2>Output</h2>
 
 {{ forms.lightswitchField({

--- a/src/twig/LlmifyExtension.php
+++ b/src/twig/LlmifyExtension.php
@@ -2,7 +2,13 @@
 
 namespace samuelreichor\llmify\twig;
 
+use Craft;
+use craft\base\ElementInterface;
+use samuelreichor\llmify\Llmify;
+use samuelreichor\llmify\services\HelperService;
 use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+use yii\base\Exception;
 
 class LlmifyExtension extends AbstractExtension
 {
@@ -12,5 +18,80 @@ class LlmifyExtension extends AbstractExtension
             new LlmifyTokenParser(),
             new ExcludeLlmifyTokenParser(),
         ];
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('mdUrl', [$this, 'getMdUrl']),
+            new TwigFunction('chatGptUrl', [$this, 'getChatGptUrl']),
+            new TwigFunction('claudeUrl', [$this, 'getClaudeUrl']),
+        ];
+    }
+
+    /**
+     * Returns the markdown URL for the given element, or the currently
+     * matched element when none is passed. Null when no element with a
+     * URI can be resolved or the element is excluded from LLMify.
+     *
+     * @throws Exception
+     */
+    public function getMdUrl(?ElementInterface $element = null): ?string
+    {
+        if ($element === null) {
+            $matched = Craft::$app->getUrlManager()->getMatchedElement();
+            $element = $matched instanceof ElementInterface ? $matched : null;
+        }
+
+        if (!$element || !$element->uri) {
+            return null;
+        }
+
+        // Read-only gating: pass triggerRefresh false so rendering a page that
+        // uses these functions never enqueues a refresh as a side effect.
+        if (!Llmify::getInstance()->refresh->canRefreshElement($element, false)) {
+            return null;
+        }
+
+        return HelperService::getMarkdownUrl($element->uri, $element->siteId);
+    }
+
+    /**
+     * Returns a link that opens ChatGPT with a prompt to read the
+     * element's markdown URL.
+     *
+     * @throws Exception
+     */
+    public function getChatGptUrl(?ElementInterface $element = null): ?string
+    {
+        return $this->promptUrl('https://chatgpt.com/?hints=search&q=', $element);
+    }
+
+    /**
+     * Returns a link that opens Claude with a prompt to read the
+     * element's markdown URL.
+     *
+     * @throws Exception
+     */
+    public function getClaudeUrl(?ElementInterface $element = null): ?string
+    {
+        return $this->promptUrl('https://claude.ai/new?q=', $element);
+    }
+
+    /**
+     * Builds a chat provider link that prompts the assistant to read the
+     * element's markdown URL. Null when the element has no markdown URL.
+     *
+     * @throws Exception
+     */
+    private function promptUrl(string $base, ?ElementInterface $element): ?string
+    {
+        $mdUrl = $this->getMdUrl($element);
+
+        if ($mdUrl === null) {
+            return null;
+        }
+
+        return $base . rawurlencode("Read {$mdUrl} so I can ask questions about it.");
     }
 }


### PR DESCRIPTION
### Added
- Add WebMCP support: the new `enableWebMcp` setting exposes your enabled content to in-browser AI agents (e.g. Gemini in Chrome) via the experimental [WebMCP](https://github.com/webmachinelearning/webmcp) standard. A script served at `/webmcp.js` registers read-only `search_content`, `get_page`, `list_sections`, and `navigate_to` tools backed by the same content gating as the public markdown routes.
- Add `WebMcpService::EVENT_REGISTER_TOOLS` so modules and plugins can register custom WebMCP tools or modify and remove the built-in ones.
- Add `mdUrl()`, `chatGptUrl()`, and `claudeUrl()` Twig functions that return the markdown URL of an element and prompt links for opening it in ChatGPT or Claude.

### Changed
- `enableBotDetection` now defaults to `false` for new installs. Serving markdown based on the user agent is an explicit opt-in.